### PR TITLE
Fix npm publishing from private repository

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,5 +94,6 @@ jobs:
       - run: npm run pack:check
       - name: Publish packages that are not in npm
         env:
+          GITHUB_REPOSITORY_VISIBILITY: ${{ github.event.repository.visibility }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: node scripts/publish-packages.mjs "${{ needs.prepare.outputs.version }}"

--- a/scripts/publish-packages.mjs
+++ b/scripts/publish-packages.mjs
@@ -8,11 +8,14 @@ if (!/^\d+\.\d+\.\d+$/.test(expectedVersion || '')) {
   throw new Error('Usage: node scripts/publish-packages.mjs <version>');
 }
 
+const useProvenance = process.env.GITHUB_REPOSITORY_VISIBILITY === 'public';
 const packages = ['core', 'codegen', 'mcp-gen', 'docs-ui', 'cli'];
 for (const workspace of packages) {
   const manifest = JSON.parse(readFileSync(`packages/${workspace}/package.json`, 'utf8'));
   if (manifest.version !== expectedVersion) {
-    throw new Error(`${manifest.name} has version ${manifest.version}. Expected ${expectedVersion}.`);
+    throw new Error(
+      `${manifest.name} has version ${manifest.version}. Expected ${expectedVersion}.`,
+    );
   }
 
   try {
@@ -24,9 +27,11 @@ for (const workspace of packages) {
   } catch {}
 
   console.log(`Publishing ${manifest.name}@${expectedVersion}...`);
-  execFileSync(
-    'npm',
-    ['publish', `--workspace=${manifest.name}`, '--access=public', '--provenance'],
-    { stdio: 'inherit' },
-  );
+  const publishArgs = ['publish', `--workspace=${manifest.name}`, '--access=public'];
+  if (useProvenance) {
+    publishArgs.push('--provenance');
+  } else {
+    console.log('Publishing without provenance because the source repository is not public.');
+  }
+  execFileSync('npm', publishArgs, { stdio: 'inherit' });
 }


### PR DESCRIPTION
## Summary

- publish without npm provenance when the GitHub repository is private
- keep provenance enabled automatically if the repository becomes public
- preserve the automated changelog and patch-release flow

## Verification

- `node --check scripts/publish-packages.mjs`
- `npx prettier --check scripts/publish-packages.mjs .github/workflows/release.yml`
- `git diff --check`

The previous `v0.1.2` publish failed only because npm provenance does not support private GitHub source repositories.