### PR TITLE
Serve the Built by Cortex badge from Cloudflare

### DIFF
--- a/e2e/docs-ui.spec.ts
+++ b/e2e/docs-ui.spec.ts
@@ -33,6 +33,22 @@ test.describe('Docs UI', () => {
     });
   });
 
+  test('loads the Built by Cortex badge from the Worker', async ({ page }) => {
+    await page.goto('/docs/quickstart');
+    const badgeLink = page.getByRole('link', { name: 'Built by Cortex' });
+    const badgeImage = badgeLink.getByRole('img', { name: 'Built by Cortex' });
+
+    await expect(badgeLink).toHaveAttribute('href', 'https://cortexdocs.dev');
+    await badgeLink.scrollIntoViewIfNeeded();
+    await expect(badgeImage).toHaveAttribute(
+      'src',
+      'http://localhost:4010/assets/built-by-cortex.svg',
+    );
+    await expect
+      .poll(() => badgeImage.evaluate((image: HTMLImageElement) => image.naturalWidth))
+      .toBe(148);
+  });
+
   test('shows authentication info', async ({ page }) => {
     await page.goto('/api-reference');
     await expect(page.locator('text=bearerAuth').first()).toBeVisible({ timeout: 15000 });

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,6 +8,7 @@ export default tseslint.config(
       '**/dist/**',
       '**/node_modules/**',
       '**/.next*/**',
+      '**/.open-next/**',
       '**/.wrangler/**',
       '**/.cortex/**',
       '**/.cortex-dev-*/**',

--- a/packages/demo-api/__tests__/worker.test.ts
+++ b/packages/demo-api/__tests__/worker.test.ts
@@ -12,6 +12,18 @@ describe('demo API Worker', () => {
     await expect(response.json()).resolves.toEqual({ status: 'ok', runtime: 'cloudflare-worker' });
   });
 
+  it('serves the Built by Cortex badge as a cached Cloudflare asset', async () => {
+    const response = await request('/assets/built-by-cortex.svg');
+    const body = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toBe('image/svg+xml; charset=utf-8');
+    expect(response.headers.get('Cache-Control')).toContain('max-age=86400');
+    expect(response.headers.get('Cross-Origin-Resource-Policy')).toBe('cross-origin');
+    expect(body).toContain('<title id="title">Built by Cortex</title>');
+    expect(body).toContain('<svg');
+  });
+
   it('returns the Petstore collection with CORS headers', async () => {
     const response = await request('/pets');
     const body = (await response.json()) as { data: Array<{ name: string }> };

--- a/packages/demo-api/src/index.ts
+++ b/packages/demo-api/src/index.ts
@@ -108,6 +108,18 @@ const corsHeaders = {
   'Access-Control-Allow-Headers': 'Authorization, Content-Type',
 };
 
+const builtByCortexBadge = `<svg xmlns="http://www.w3.org/2000/svg" width="148" height="36" viewBox="0 0 148 36" role="img" aria-labelledby="title">
+  <title id="title">Built by Cortex</title>
+  <rect x="0.5" y="0.5" width="147" height="35" rx="9.5" fill="#0a0a0a" stroke="#ffffff" stroke-opacity="0.15"/>
+  <g transform="translate(7 8)" fill="none" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M9 2.5Q11 1 13 2.5L18 5Q20 6 18 7L13 9.5Q11 11 9 9.5L4 7Q2 6 4 5L9 2.5Z" stroke-width="1.5" fill="#ffffff" fill-opacity="0.1"/>
+    <path d="M3 10L9 13.5Q11 14.8 13 13.5L19 10" stroke-width="1.5"/>
+    <path d="M3 13.5L9 17Q11 18.3 13 17L19 13.5" stroke-width="1.5" opacity="0.5"/>
+  </g>
+  <text x="37" y="21.5" fill="#a1a1aa" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="11">Built by</text>
+  <text x="77" y="21.5" fill="#ffffff" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="11" font-weight="600">Cortex</text>
+</svg>`;
+
 function json(data: unknown, status = 200): Response {
   return Response.json(data, {
     status,
@@ -122,6 +134,19 @@ function withCors(response: Response): Response {
   const headers = new Headers(response.headers);
   for (const [name, value] of Object.entries(corsHeaders)) headers.set(name, value);
   return new Response(response.body, { status: response.status, headers });
+}
+
+function builtByCortexBadgeResponse(method: string): Response {
+  return new Response(method === 'HEAD' ? null : builtByCortexBadge, {
+    headers: {
+      ...corsHeaders,
+      'Cache-Control': 'public, max-age=86400, stale-while-revalidate=604800',
+      'Content-Security-Policy': "default-src 'none'; script-src 'none'; style-src 'none'; sandbox",
+      'Content-Type': 'image/svg+xml; charset=utf-8',
+      'Cross-Origin-Resource-Policy': 'cross-origin',
+      'X-Content-Type-Options': 'nosniff',
+    },
+  });
 }
 
 async function readJson(request: Request): Promise<Record<string, any>> {
@@ -325,6 +350,10 @@ async function handleRequest(request: Request): Promise<Response> {
   const method = request.method;
 
   if (method === 'OPTIONS') return new Response(null, { status: 204, headers: corsHeaders });
+
+  if (path === '/assets/built-by-cortex.svg' && (method === 'GET' || method === 'HEAD')) {
+    return builtByCortexBadgeResponse(method);
+  }
 
   if (request.headers.get('Upgrade')?.toLowerCase() === 'websocket') {
     if (path === '/ws') return websocketResponse(request, false);

--- a/packages/docs-ui/app/docs/[slug]/page.tsx
+++ b/packages/docs-ui/app/docs/[slug]/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { use, useEffect, useMemo, useRef, useState } from 'react';
+import Image from 'next/image';
 import Link from 'next/link';
 
 import { DocsBreadcrumb, type BreadcrumbSegment } from '@/components/docs/docs-breadcrumb';
@@ -13,6 +14,10 @@ interface TocItem {
   text: string;
   level: number;
 }
+
+const BUILT_BY_CORTEX_BADGE_URL =
+  process.env.NEXT_PUBLIC_CORTEX_BUILT_BY_BADGE_URL ??
+  'https://api.demo.cortexdocs.dev/assets/built-by-cortex.svg';
 
 function extractToc(html: string): TocItem[] {
   const items: TocItem[] = [];
@@ -253,35 +258,16 @@ export default function DocSlugPage({ params }: { params: Promise<{ slug: string
                     href="https://cortexdocs.dev"
                     target="_blank"
                     rel="noopener noreferrer"
-                    aria-label="Visit Cortex Docs"
-                    className="inline-flex items-center gap-2 rounded-[10px] border border-white/15 bg-[#0a0a0a] px-3 py-2 shadow-sm transition-colors hover:bg-[#18181b] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                    aria-label="Built by Cortex"
+                    className="inline-flex rounded-[10px] shadow-sm transition-opacity hover:opacity-85 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
                   >
-                    <svg
-                      className="size-5 shrink-0 text-white"
-                      viewBox="0 0 22 20"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      aria-hidden="true"
-                    >
-                      <path
-                        d="M9 2.5Q11 1 13 2.5L18 5Q20 6 18 7L13 9.5Q11 11 9 9.5L4 7Q2 6 4 5L9 2.5Z"
-                        strokeWidth="1.5"
-                        fill="currentColor"
-                        fillOpacity="0.1"
-                      />
-                      <path d="M3 10L9 13.5Q11 14.8 13 13.5L19 10" strokeWidth="1.5" />
-                      <path
-                        d="M3 13.5L9 17Q11 18.3 13 17L19 13.5"
-                        strokeWidth="1.5"
-                        opacity="0.5"
-                      />
-                    </svg>
-                    <span className="inline-flex items-baseline gap-1 whitespace-nowrap text-xs leading-none">
-                      <span className="text-zinc-400">Built with</span>
-                      <span className="font-semibold text-white">Cortex Docs</span>
-                    </span>
+                    <Image
+                      src={BUILT_BY_CORTEX_BADGE_URL}
+                      alt="Built by Cortex"
+                      width={148}
+                      height={36}
+                      unoptimized
+                    />
                   </a>
                 </footer>
               </>

--- a/packages/docs-ui/next.config.js
+++ b/packages/docs-ui/next.config.js
@@ -9,6 +9,23 @@ if (process.env.CORTEX_CLOUDFLARE === '1') {
 /** @type {import('next').NextConfig} */
 module.exports = {
   reactStrictMode: true,
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'api.demo.cortexdocs.dev',
+        port: '',
+        pathname: '/assets/built-by-cortex.svg',
+        search: '',
+      },
+      {
+        protocol: 'http',
+        hostname: 'localhost',
+        pathname: '/assets/built-by-cortex.svg',
+        search: '',
+      },
+    ],
+  },
   serverExternalPackages: [
     '@cortex-docs/core',
     '@cortex-docs/codegen',

--- a/packages/docs-ui/scripts/cloudflare.mjs
+++ b/packages/docs-ui/scripts/cloudflare.mjs
@@ -15,12 +15,14 @@ const scriptDir = dirname(fileURLToPath(import.meta.url));
 const docsUiDir = resolve(scriptDir, '..');
 const workspaceRoot = resolve(docsUiDir, '..', '..');
 const cli = resolve(workspaceRoot, 'node_modules', '.bin', 'opennextjs-cloudflare');
-const prepared = prepareDemo();
+const demoApiUrl = process.env.CORTEX_DEMO_API_URL || 'http://localhost:4010';
+const prepared = prepareDemo(demoApiUrl);
 
 const env = {
   ...process.env,
   CORTEX_CLOUDFLARE: '1',
   NEXT_PUBLIC_CORTEX_CLOUDFLARE: '1',
+  NEXT_PUBLIC_CORTEX_BUILT_BY_BADGE_URL: `${demoApiUrl}/assets/built-by-cortex.svg`,
   CORTEX_DIST_DIR: '.next',
   CORTEX_DOCS_UI_ROOT: docsUiDir,
   CORTEX_CONFIG_PATH: prepared.configPath,

--- a/packages/docs-ui/scripts/dev.mjs
+++ b/packages/docs-ui/scripts/dev.mjs
@@ -258,6 +258,12 @@ function startDocsServe() {
   log('serve', `Starting cortex docs serve on http://localhost:${PORT}`);
   const proc = spawn('node', [CLI_MAIN, 'docs', 'serve', '--port', PORT], {
     cwd: TEST_PROJECT_DIR,
+    env: {
+      ...process.env,
+      NEXT_PUBLIC_CORTEX_BUILT_BY_BADGE_URL:
+        process.env.NEXT_PUBLIC_CORTEX_BUILT_BY_BADGE_URL ||
+        `http://localhost:${MOCK_PORT}/assets/built-by-cortex.svg`,
+    },
     detached: false,
     stdio: 'inherit',
   });


### PR DESCRIPTION
## Summary

- replace the inline docs footer badge with an external Built by Cortex SVG
- serve and cache the SVG from the demo API Cloudflare Worker
- use the local Worker during development and the Cloudflare URL in production
- cover the Worker asset and docs UI integration with tests

## Verification

- formatting and lint pass
- demo API and docs UI unit tests pass
- docs UI production build passes
- direct Playwright validation confirms the badge loads from the Worker at 148×36 with zero console errors