### PR TITLE
Release product docs and MCP package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release npm packages
+name: Release packages and docs
 
 on:
   workflow_run:
@@ -72,10 +72,10 @@ jobs:
           echo "release_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
   publish:
-    name: publish npm packages
+    name: publish packages and deploy docs
     needs: prepare
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     environment: npm
     permissions:
       contents: read
@@ -97,3 +97,22 @@ jobs:
           GITHUB_REPOSITORY_VISIBILITY: ${{ github.event.repository.visibility }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: node scripts/publish-packages.mjs "${{ needs.prepare.outputs.version }}"
+      - name: Publish the product docs MCP package
+        env:
+          GITHUB_REPOSITORY_VISIBILITY: ${{ github.event.repository.visibility }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: node scripts/publish-docs-mcp.mjs "${{ needs.prepare.outputs.version }}"
+      - name: Make sure that the Cloudflare zone is active
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+        run: |
+          curl --fail --silent --show-error \
+            --header "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+            "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}" \
+            | jq --exit-status '.success == true and .result.status == "active"'
+      - name: Deploy the product docs Worker
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: npm run --workspace=@cortex-docs/docs-ui docs:deploy

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ dist/
 .open-next/
 .wrangler/
 .cortex-demo/
+.cortex-docs-site/
 .cortex-dev-*/
 .cortex-build-*/
 .turbo/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,9 @@ npm run pack:check
 
 Do not open a feature pull request to `main`. Maintainers promote `pre-release` to `main` after the required checks pass.
 
-The promotion pull request runs all Docker integration tests. A merge to `main` deploys the demo and publishes a new patch version.
+The promotion pull request runs all Docker integration tests. A merge to `main` publishes a new patch version.
+
+The release also publishes `@cortex-docs/mcp` and deploys `docs.cortexdocs.dev`. The demo deploys through its separate workflow.
 
 Read [RELEASING.md](RELEASING.md) for the complete promotion and release flow.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ Cortex Docs generates typed SDKs, interactive API documentation, and Model Conte
 
 One project can combine OpenAPI, AsyncAPI, GraphQL, Protocol Buffer, and OpenRPC sources. Cortex Docs generates one package for each configured language.
 
-## Live demo
+## Live sites
+
+**[Read the Cortex Docs documentation →](https://docs.cortexdocs.dev)**
 
 **[Open the Cortex Docs demo →](https://demo.cortexdocs.dev)**
 
@@ -154,6 +156,7 @@ The generated package contains local copies of every configured specification. I
 | `@cortex-docs/core`    | Configuration loader and specification parsers |
 | `@cortex-docs/codegen` | SDK generation engine and language templates   |
 | `@cortex-docs/mcp-gen` | MCP server generator                           |
+| `@cortex-docs/mcp`     | MCP server for the Cortex Docs documentation   |
 | `@cortex-docs/docs-ui` | Documentation runtime used by the CLI          |
 
 ## Documentation

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -27,7 +27,7 @@ A promotion pull request to `main` also runs the `integration` check. This check
 
 After a merge to `main`, the `CI` workflow runs again. A successful run starts the deployment and release workflows.
 
-The deployment workflow performs these actions:
+The demo deployment workflow performs these actions:
 
 1. Build all packages.
 2. Make sure that the configured Cloudflare zone is active.
@@ -44,7 +44,13 @@ The release workflow performs these actions:
 5. Update `CHANGELOG.md` with the release notes.
 6. Commit the version and changelog changes to `main`.
 7. Create the matching `vX.X.X` tag.
-8. Publish the five public `@cortex` packages to npm.
+8. Publish the five public workspace packages to npm.
+9. Generate `@cortex-docs/mcp` from the product documentation.
+10. Publish `@cortex-docs/mcp` with the same release version.
+11. Build the product documentation with OpenNext.
+12. Deploy the release to `docs.cortexdocs.dev`.
+
+The release stops before the product docs deployment if an npm publication fails. A rerun skips package versions that already exist.
 
 The release notes always contain these sections:
 
@@ -97,8 +103,26 @@ Run this command to build the demo for the Cloudflare runtime:
 npm run --workspace=@cortex-docs/docs-ui demo:build
 ```
 
+Run this command to build the product docs for the Cloudflare runtime:
+
+```bash
+npm run --workspace=@cortex-docs/docs-ui docs:build
+```
+
+Run this command to generate, build, and pack the product docs MCP package:
+
+```bash
+node scripts/publish-docs-mcp.mjs 0.0.0 --dry-run
+```
+
 Run this command to preview the Cloudflare build:
 
 ```bash
 npm run --workspace=@cortex-docs/docs-ui demo:preview
+```
+
+Run this command to preview the product docs build:
+
+```bash
+npm run --workspace=@cortex-docs/docs-ui docs:preview
 ```

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:sdk:ci": "docker compose -f e2e/docker/docker-compose.ci.yml up --abort-on-container-exit --exit-code-from sdk-tests",
     "test:publish:e2e": "docker build -t cortex-base -f Dockerfile . && docker compose -f e2e/publish/docker-compose.yml down --volumes --remove-orphans && docker compose -f e2e/publish/docker-compose.yml up --build --abort-on-container-exit --exit-code-from publish-tests",
     "test:publish:e2e:ci": "docker compose -f e2e/publish/docker-compose.ci.yml down --volumes --remove-orphans && docker compose -f e2e/publish/docker-compose.ci.yml up --abort-on-container-exit --exit-code-from publish-tests",
-    "pack:check": "npm pack --dry-run --workspace=@cortex-docs/core && npm pack --dry-run --workspace=@cortex-docs/codegen && npm pack --dry-run --workspace=@cortex-docs/mcp-gen && npm pack --dry-run --workspace=@cortex-docs/docs-ui && npm pack --dry-run --workspace=@cortex-docs/cli"
+    "pack:check": "npm pack --dry-run --workspace=@cortex-docs/core && npm pack --dry-run --workspace=@cortex-docs/codegen && npm pack --dry-run --workspace=@cortex-docs/mcp-gen && npm pack --dry-run --workspace=@cortex-docs/docs-ui && npm pack --dry-run --workspace=@cortex-docs/cli && node scripts/publish-docs-mcp.mjs 0.0.0 --dry-run"
   },
   "devDependencies": {
     "@apollo/server": "^5.5.1",

--- a/packages/docs-site/cortex.config.yml
+++ b/packages/docs-site/cortex.config.yml
@@ -55,4 +55,11 @@ docs:
         document: docs/mcp-servers.md
       - title: Publishing
         document: docs/publishing.md
-mcp: {}
+mcp:
+  package_name: '@cortex-docs/mcp'
+  github_repository: github.com/cortex-docs/cortex
+publish:
+  mcp:
+    url: https://registry.npmjs.org
+    token_env: NPM_TOKEN
+    access: public

--- a/packages/docs-ui/next.config.js
+++ b/packages/docs-ui/next.config.js
@@ -35,6 +35,6 @@ module.exports = {
   distDir: process.env.CORTEX_DIST_DIR || '.next',
   outputFileTracingRoot: path.resolve(docsUiRoot, '../..'),
   outputFileTracingIncludes: {
-    '/*': ['./.cortex-demo/**/*'],
+    '/*': ['./.cortex-demo/**/*', './.cortex-docs-site/**/*'],
   },
 };

--- a/packages/docs-ui/package.json
+++ b/packages/docs-ui/package.json
@@ -45,11 +45,14 @@
     "demo:build": "node scripts/cloudflare.mjs build",
     "demo:preview": "node scripts/cloudflare.mjs preview",
     "demo:deploy": "node scripts/cloudflare.mjs deploy",
+    "docs:build": "node scripts/cloudflare.mjs build docs",
+    "docs:preview": "node scripts/cloudflare.mjs preview docs",
+    "docs:deploy": "node scripts/cloudflare.mjs deploy docs",
     "cf:typegen": "wrangler types --env-interface CloudflareEnv cloudflare-env.d.ts",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "start": "next start",
-    "clean": "rm -rf .next .next-build .open-next .cortex-demo"
+    "clean": "rm -rf .next .next-build .open-next .cortex-demo .cortex-docs-site"
   },
   "dependencies": {
     "@base-ui/react": "^1.5.0",

--- a/packages/docs-ui/scripts/cloudflare.mjs
+++ b/packages/docs-ui/scripts/cloudflare.mjs
@@ -4,10 +4,16 @@ import { spawn } from 'node:child_process';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { prepareDemo } from './prepare-demo.mjs';
+import { prepareDocsSite } from './prepare-docs-site.mjs';
 
 const command = process.argv[2];
+const target = process.argv[3] ?? 'demo';
 if (!['build', 'preview', 'deploy'].includes(command)) {
-  console.error('Usage: node scripts/cloudflare.mjs <build|preview|deploy>');
+  console.error('Usage: node scripts/cloudflare.mjs <build|preview|deploy> [demo|docs]');
+  process.exit(1);
+}
+if (!['demo', 'docs'].includes(target)) {
+  console.error('The Cloudflare target must be "demo" or "docs".');
   process.exit(1);
 }
 
@@ -16,29 +22,42 @@ const docsUiDir = resolve(scriptDir, '..');
 const workspaceRoot = resolve(docsUiDir, '..', '..');
 const cli = resolve(workspaceRoot, 'node_modules', '.bin', 'opennextjs-cloudflare');
 const demoApiUrl = process.env.CORTEX_DEMO_API_URL || 'http://localhost:4010';
-const prepared = prepareDemo(demoApiUrl);
+const prepared = target === 'demo' ? prepareDemo(demoApiUrl) : prepareDocsSite();
+const wranglerConfig = resolve(
+  docsUiDir,
+  target === 'demo' ? 'wrangler.jsonc' : 'wrangler.docs-site.jsonc',
+);
+const badgeUrl =
+  process.env.CORTEX_BUILT_BY_BADGE_URL ||
+  (target === 'demo'
+    ? `${demoApiUrl}/assets/built-by-cortex.svg`
+    : 'https://api.demo.cortexdocs.dev/assets/built-by-cortex.svg');
 
 const env = {
   ...process.env,
   CORTEX_CLOUDFLARE: '1',
   NEXT_PUBLIC_CORTEX_CLOUDFLARE: '1',
-  NEXT_PUBLIC_CORTEX_BUILT_BY_BADGE_URL: `${demoApiUrl}/assets/built-by-cortex.svg`,
+  NEXT_PUBLIC_CORTEX_BUILT_BY_BADGE_URL: badgeUrl,
   CORTEX_DIST_DIR: '.next',
   CORTEX_DOCS_UI_ROOT: docsUiDir,
   CORTEX_CONFIG_PATH: prepared.configPath,
-  CORTEX_SPEC_PATH: prepared.specPath,
-  CORTEX_ASYNCAPI_PATH: prepared.asyncApiPath,
-  CORTEX_GRAPHQL_PATH: prepared.graphqlPath,
-  CORTEX_GRPC_PATH: prepared.grpcPath,
-  CORTEX_OPENRPC_PATH: prepared.openRpcPath,
   CORTEX_LOGO_PATH: prepared.logoPath,
   CORTEX_FAVICON_PATH: prepared.faviconPath,
+  ...(target === 'demo'
+    ? {
+        CORTEX_SPEC_PATH: prepared.specPath,
+        CORTEX_ASYNCAPI_PATH: prepared.asyncApiPath,
+        CORTEX_GRAPHQL_PATH: prepared.graphqlPath,
+        CORTEX_GRPC_PATH: prepared.grpcPath,
+        CORTEX_OPENRPC_PATH: prepared.openRpcPath,
+      }
+    : {}),
   NEXTJS_ENV: command === 'preview' ? 'development' : 'production',
 };
 
 function runOpenNext(subcommand) {
   return new Promise((resolveCommand, rejectCommand) => {
-    const child = spawn(cli, [subcommand], {
+    const child = spawn(cli, [subcommand, '--config', wranglerConfig], {
       cwd: docsUiDir,
       env,
       stdio: 'inherit',

--- a/packages/docs-ui/scripts/prepare-docs-site.mjs
+++ b/packages/docs-ui/scripts/prepare-docs-site.mjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+
+import { cpSync, mkdirSync, rmSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const docsUiDir = resolve(scriptDir, '..');
+const workspaceRoot = resolve(docsUiDir, '..', '..');
+const defaultSourceDir = join(workspaceRoot, 'packages', 'docs-site');
+const defaultTargetDir = join(docsUiDir, '.cortex-docs-site');
+
+export function prepareDocsSite(sourceDir = defaultSourceDir, targetDir = defaultTargetDir) {
+  rmSync(targetDir, { recursive: true, force: true });
+  mkdirSync(targetDir, { recursive: true });
+
+  cpSync(join(sourceDir, 'cortex.config.yml'), join(targetDir, 'cortex.config.yml'));
+  cpSync(join(sourceDir, 'docs'), join(targetDir, 'docs'), { recursive: true });
+  cpSync(join(sourceDir, 'assets'), join(targetDir, 'assets'), { recursive: true });
+
+  return {
+    siteDir: targetDir,
+    configPath: join(targetDir, 'cortex.config.yml'),
+    logoPath: join(targetDir, 'assets', 'logo_light.svg'),
+    faviconPath: join(targetDir, 'assets', 'favicon.svg'),
+  };
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const prepared = prepareDocsSite();
+  console.log(`Prepared the product docs at ${prepared.siteDir}`);
+}

--- a/packages/docs-ui/wrangler.docs-site.jsonc
+++ b/packages/docs-ui/wrangler.docs-site.jsonc
@@ -1,0 +1,38 @@
+{
+  "$schema": "../../node_modules/wrangler/config-schema.json",
+  "name": "cortex-docs-site",
+  "main": ".open-next/worker.js",
+  "find_additional_modules": true,
+  "base_dir": ".open-next",
+  "rules": [
+    {
+      "type": "Text",
+      "globs": ["server-functions/default/packages/docs-ui/.cortex-docs-site/**/*"],
+      "fallthrough": true,
+    },
+  ],
+  "compatibility_date": "2026-08-24",
+  "compatibility_flags": ["nodejs_compat", "global_fetch_strictly_public"],
+  "workers_dev": false,
+  "routes": [
+    {
+      "pattern": "docs.cortexdocs.dev",
+      "custom_domain": true,
+    },
+  ],
+  "assets": {
+    "directory": ".open-next/assets",
+    "binding": "ASSETS",
+  },
+  "observability": {
+    "enabled": true,
+  },
+  "vars": {
+    "NEXTJS_ENV": "production",
+    "CORTEX_CLOUDFLARE": "1",
+    "CORTEX_DOCS_UI_ROOT": "/bundle/server-functions/default/packages/docs-ui",
+    "CORTEX_CONFIG_PATH": "/bundle/server-functions/default/packages/docs-ui/.cortex-docs-site/cortex.config.yml",
+    "CORTEX_LOGO_PATH": "/bundle/server-functions/default/packages/docs-ui/.cortex-docs-site/assets/logo_light.svg",
+    "CORTEX_FAVICON_PATH": "/bundle/server-functions/default/packages/docs-ui/.cortex-docs-site/assets/favicon.svg",
+  },
+}

--- a/scripts/publish-docs-mcp.mjs
+++ b/scripts/publish-docs-mcp.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const version = process.argv[2];
+const dryRun = process.argv.includes('--dry-run');
+if (!/^\d+\.\d+\.\d+$/.test(version || '')) {
+  throw new Error('Usage: node scripts/publish-docs-mcp.mjs <version> [--dry-run]');
+}
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const workspaceRoot = resolve(scriptDir, '..');
+const docsSiteDir = join(workspaceRoot, 'packages', 'docs-site');
+const outputDir = join(docsSiteDir, '.cortex', 'release-mcp');
+const cli = join(workspaceRoot, 'packages', 'cli', 'dist', 'main.js');
+
+rmSync(outputDir, { recursive: true, force: true });
+mkdirSync(outputDir, { recursive: true });
+writeFileSync(join(outputDir, '.cortex-package.json'), `${JSON.stringify({ version })}\n`);
+
+execFileSync(process.execPath, [cli, 'mcp', 'generate', '--output', outputDir], {
+  cwd: docsSiteDir,
+  stdio: 'inherit',
+});
+
+const manifest = JSON.parse(readFileSync(join(outputDir, 'package.json'), 'utf8'));
+if (manifest.name !== '@cortex-docs/mcp') {
+  throw new Error(`Generated ${manifest.name}. Expected @cortex-docs/mcp.`);
+}
+if (manifest.version !== version) {
+  throw new Error(`Generated version ${manifest.version}. Expected ${version}.`);
+}
+
+const npmArgs = (args) => [...args, '--workspaces=false'];
+execFileSync('npm', npmArgs(['install', '--ignore-scripts', '--package-lock=false']), {
+  cwd: outputDir,
+  stdio: 'inherit',
+});
+execFileSync('npm', npmArgs(['run', 'build']), { cwd: outputDir, stdio: 'inherit' });
+execFileSync('npm', npmArgs(['pack', '--dry-run']), { cwd: outputDir, stdio: 'inherit' });
+
+if (dryRun) {
+  console.log(`Dry run complete for @cortex-docs/mcp@${version}.`);
+  process.exit(0);
+}
+
+try {
+  execFileSync('npm', ['view', `@cortex-docs/mcp@${version}`, 'version'], { stdio: 'ignore' });
+  console.log(`Skipping @cortex-docs/mcp@${version}. It is already published.`);
+  process.exit(0);
+} catch {}
+
+const publishArgs = npmArgs(['publish', '--access=public']);
+if (process.env.GITHUB_REPOSITORY_VISIBILITY === 'public') publishArgs.push('--provenance');
+execFileSync('npm', publishArgs, { cwd: outputDir, stdio: 'inherit' });


### PR DESCRIPTION
## Summary

- deploy the product documentation to `docs.cortexdocs.dev` from each successful release
- generate and publish `@cortex-docs/mcp` with the same release version
- validate the generated MCP tarball in every pull request
- document the release flow and add the live documentation link

## Validation

- `npm run format:check`
- `npm run lint`
- `npm test`
- `npm run pack:check`
- `npm audit --audit-level=high`
- product docs configuration validation
- generated MCP build and dry-run package check

The exact local OpenNext build is blocked by a Yarn Plug-and-Play manifest in the user home directory. GitHub Actions uses a clean npm runner and validates the Worker build during release.