### PR TITLE
fix: build bundled workspaces before CLI pack

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19858,10 +19858,10 @@
       "name": "@cortex-docs/cli",
       "version": "0.1.6",
       "bundleDependencies": [
-        "@cortex-docs/codegen",
         "@cortex-docs/core",
-        "@cortex-docs/docs-ui",
-        "@cortex-docs/mcp-gen"
+        "@cortex-docs/codegen",
+        "@cortex-docs/mcp-gen",
+        "@cortex-docs/docs-ui"
       ],
       "license": "MIT",
       "dependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -59,10 +59,10 @@
     "rxjs": "^7.8.0"
   },
   "bundleDependencies": [
-    "@cortex-docs/codegen",
     "@cortex-docs/core",
-    "@cortex-docs/docs-ui",
-    "@cortex-docs/mcp-gen"
+    "@cortex-docs/codegen",
+    "@cortex-docs/mcp-gen",
+    "@cortex-docs/docs-ui"
   ],
   "devDependencies": {
     "@types/glob": "^8.1.0",

--- a/scripts/publish-cli.mjs
+++ b/scripts/publish-cli.mjs
@@ -17,10 +17,10 @@ const workspaceRoot = resolve(scriptDir, '..');
 const cliManifestPath = join(workspaceRoot, 'packages', 'cli', 'package.json');
 const cliManifest = JSON.parse(readFileSync(cliManifestPath, 'utf8'));
 const bundledPackages = [
-  '@cortex-docs/codegen',
   '@cortex-docs/core',
-  '@cortex-docs/docs-ui',
+  '@cortex-docs/codegen',
   '@cortex-docs/mcp-gen',
+  '@cortex-docs/docs-ui',
 ];
 
 if (!dryRun && cliManifest.version !== expectedVersion) {
@@ -62,6 +62,9 @@ function extractPackage(archive, target) {
 }
 
 try {
+  const bundledArchives = new Map(
+    bundledPackages.map((packageName) => [packageName, packWorkspace(packageName)]),
+  );
   extractPackage(packWorkspace(cliManifest.name), stagingPackage);
 
   const stagedManifestPath = join(stagingPackage, 'package.json');
@@ -72,7 +75,7 @@ try {
 
   for (const packageName of bundledPackages) {
     const target = join(stagingPackage, 'node_modules', ...packageName.split('/'));
-    extractPackage(packWorkspace(packageName), target);
+    extractPackage(bundledArchives.get(packageName), target);
   }
 
   execFileSync(


### PR DESCRIPTION
## Summary
- build bundled workspace packages before compiling and packing the CLI
- keep the bundle order dependency-safe: core, codegen, mcp-gen, docs-ui

## Root cause
The release preparation job does not run the full monorepo build before pack:check. The CLI pack therefore ran before its internal type declarations existed.

## Validation
Reproduced the release sequence in a clean isolated worktree:
- npm ci
- set release version to 0.1.7
- update package lock
- format check
- package check