### PR TITLE
release: promote CLI pack-order fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19858,10 +19858,10 @@
       "name": "@cortex-docs/cli",
       "version": "0.1.6",
       "bundleDependencies": [
-        "@cortex-docs/codegen",
         "@cortex-docs/core",
-        "@cortex-docs/docs-ui",
-        "@cortex-docs/mcp-gen"
+        "@cortex-docs/codegen",
+        "@cortex-docs/mcp-gen",
+        "@cortex-docs/docs-ui"
       ],
       "license": "MIT",
       "dependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -59,10 +59,10 @@
     "rxjs": "^7.8.0"
   },
   "bundleDependencies": [
-    "@cortex-docs/codegen",
     "@cortex-docs/core",
-    "@cortex-docs/docs-ui",
-    "@cortex-docs/mcp-gen"
+    "@cortex-docs/codegen",
+    "@cortex-docs/mcp-gen",
+    "@cortex-docs/docs-ui"
   ],
   "devDependencies": {
     "@types/glob": "^8.1.0",

--- a/scripts/publish-cli.mjs
+++ b/scripts/publish-cli.mjs
@@ -17,10 +17,10 @@ const workspaceRoot = resolve(scriptDir, '..');
 const cliManifestPath = join(workspaceRoot, 'packages', 'cli', 'package.json');
 const cliManifest = JSON.parse(readFileSync(cliManifestPath, 'utf8'));
 const bundledPackages = [
-  '@cortex-docs/codegen',
   '@cortex-docs/core',
-  '@cortex-docs/docs-ui',
+  '@cortex-docs/codegen',
   '@cortex-docs/mcp-gen',
+  '@cortex-docs/docs-ui',
 ];
 
 if (!dryRun && cliManifest.version !== expectedVersion) {
@@ -62,6 +62,9 @@ function extractPackage(archive, target) {
 }
 
 try {
+  const bundledArchives = new Map(
+    bundledPackages.map((packageName) => [packageName, packWorkspace(packageName)]),
+  );
   extractPackage(packWorkspace(cliManifest.name), stagingPackage);
 
   const stagedManifestPath = join(stagingPackage, 'package.json');
@@ -72,7 +75,7 @@ try {
 
   for (const packageName of bundledPackages) {
     const target = join(stagingPackage, 'node_modules', ...packageName.split('/'));
-    extractPackage(packWorkspace(packageName), target);
+    extractPackage(bundledArchives.get(packageName), target);
   }
 
   execFileSync(


### PR DESCRIPTION
## Summary
- build bundled internal workspaces before the CLI package
- correct the clean release-runner failure found before v0.1.7 publication

The exact release preparation sequence passes in an isolated clean worktree.