### PR TITLE
Fix Ruby WebSocket callback race

### DIFF
--- a/packages/codegen/__tests__/ws-codegen.test.ts
+++ b/packages/codegen/__tests__/ws-codegen.test.ts
@@ -93,4 +93,17 @@ describe('WebSocket Codegen — resilience', () => {
     expect(client.content).toContain('catch (ObjectDisposedException) { }');
     expect(client.content).toContain('if (!_shouldReconnect) return;');
   });
+
+  it('registers Ruby socket callbacks before the reader thread starts', async () => {
+    const files = await generateWs('ruby', heartbeat);
+    const client = files.find((file) => file.path.includes('ws-client'))!;
+
+    expect(client.content).toContain('WebSocket::Client::Simple.connect(@url) do |socket|');
+    expect(client.content).toContain('@ws = socket');
+    expect(client.content).toContain('socket.on :open do');
+    expect(client.content).toContain('client.send(:_handle_open)');
+    expect(client.content).toContain('def _handle_open');
+    expect(client.content).toContain('socket.on :close do |_e|');
+    expect(client.content).not.toContain('@ws = WebSocket::Client::Simple.connect(@url)');
+  });
 });

--- a/packages/codegen/src/languages/ruby/templates/websocket/client.ejs
+++ b/packages/codegen/src/languages/ruby/templates/websocket/client.ejs
@@ -39,25 +39,29 @@ class <%= it.clientClass %>
 
   def connect
     @manually_closed = false
-    @ws = WebSocket::Client::Simple.connect(@url)
-    @reconnect_attempts = 0
     client = self
 
-    @ws.on :message do |msg|
-      client.send(:_handle_message, msg.data)
-    end
+    # websocket-client-simple starts its reader thread before connect returns.
+    # Register callbacks in its setup block so an immediate open or close event
+    # cannot occur before the generated client is listening for it.
+    WebSocket::Client::Simple.connect(@url) do |socket|
+      @ws = socket
 
-    @ws.on :open do
-      @last_activity = Time.now
-      client.send(:_start_heartbeat)
-    end
+      socket.on :message do |msg|
+        client.send(:_handle_message, msg.data)
+      end
 
-    @ws.on :close do |_e|
-      client.send(:_handle_close)
-    end
+      socket.on :open do
+        client.send(:_handle_open)
+      end
 
-    @ws.on :error do |e|
-      # connection error
+      socket.on :close do |_e|
+        client.send(:_handle_close)
+      end
+
+      socket.on :error do |_e|
+        # connection error
+      end
     end
 
     self
@@ -114,6 +118,12 @@ class <%= it.clientClass %>
 <% } -%>
 <% } -%>
   private
+
+  def _handle_open
+    @reconnect_attempts = 0
+    @last_activity = Time.now
+    _start_heartbeat
+  end
 
   def _handle_message(raw)
     if _heartbeat_matches(raw, @server_heartbeat_message)


### PR DESCRIPTION
## Summary

- register Ruby WebSocket callbacks before `websocket-client-simple` starts its reader thread
- update heartbeat state through the generated client instead of the callback socket context
- add a code-generation regression test for callback setup order

## Root cause

`websocket-client-simple` starts reading before `connect` returns. The generated SDK attached callbacks afterward, so a fast server could emit `open` before the heartbeat callback existed. Its event emitter also runs blocks with the socket as `self`, which caused the old `@last_activity` assignments to update the dependency socket instead of the generated client.

## Verification

- 50/50 forced-disconnect Ruby reconnect and heartbeat cycles passed
- `npm run format:check`
- `npm run lint`
- `npm run build`
- `npm run test:coverage`
