### PR TITLE
Promote Ruby WebSocket race fix

### DIFF
--- a/packages/codegen/__tests__/ws-codegen.test.ts
+++ b/packages/codegen/__tests__/ws-codegen.test.ts
@@ -93,4 +93,17 @@ describe('WebSocket Codegen — resilience', () => {
     expect(client.content).toContain('catch (ObjectDisposedException) { }');
     expect(client.content).toContain('if (!_shouldReconnect) return;');
   });
+
+  it('registers Ruby socket callbacks before the reader thread starts', async () => {
+    const files = await generateWs('ruby', heartbeat);
+    const client = files.find((file) => file.path.includes('ws-client'))!;
+
+    expect(client.content).toContain('WebSocket::Client::Simple.connect(@url) do |socket|');
+    expect(client.content).toContain('@ws = socket');
+    expect(client.content).toContain('socket.on :open do');
+    expect(client.content).toContain('client.send(:_handle_open)');
+    expect(client.content).toContain('def _handle_open');
+    expect(client.content).toContain('socket.on :close do |_e|');
+    expect(client.content).not.toContain('@ws = WebSocket::Client::Simple.connect(@url)');
+  });
 });

--- a/packages/codegen/src/languages/ruby/templates/websocket/client.ejs
+++ b/packages/codegen/src/languages/ruby/templates/websocket/client.ejs
@@ -39,25 +39,29 @@ class <%= it.clientClass %>
 
   def connect
     @manually_closed = false
-    @ws = WebSocket::Client::Simple.connect(@url)
-    @reconnect_attempts = 0
     client = self
 
-    @ws.on :message do |msg|
-      client.send(:_handle_message, msg.data)
-    end
+    # websocket-client-simple starts its reader thread before connect returns.
+    # Register callbacks in its setup block so an immediate open or close event
+    # cannot occur before the generated client is listening for it.
+    WebSocket::Client::Simple.connect(@url) do |socket|
+      @ws = socket
 
-    @ws.on :open do
-      @last_activity = Time.now
-      client.send(:_start_heartbeat)
-    end
+      socket.on :message do |msg|
+        client.send(:_handle_message, msg.data)
+      end
 
-    @ws.on :close do |_e|
-      client.send(:_handle_close)
-    end
+      socket.on :open do
+        client.send(:_handle_open)
+      end
 
-    @ws.on :error do |e|
-      # connection error
+      socket.on :close do |_e|
+        client.send(:_handle_close)
+      end
+
+      socket.on :error do |_e|
+        # connection error
+      end
     end
 
     self
@@ -114,6 +118,12 @@ class <%= it.clientClass %>
 <% } -%>
 <% } -%>
   private
+
+  def _handle_open
+    @reconnect_attempts = 0
+    @last_activity = Time.now
+    _start_heartbeat
+  end
 
   def _handle_message(raw)
     if _heartbeat_matches(raw, @server_heartbeat_message)


### PR DESCRIPTION
## Summary

Promote the Ruby WebSocket callback-order and heartbeat-state fix from `pre-release` to `main`.

## Verification before promotion

- deterministic forced-disconnect Ruby harness: 50/50 passed
- repository build, lint, format, and coverage passed locally
- PR #16 quality and browser checks passed

The `main` promotion runs the prebuilt Docker SDK and package publication integration suites.
