### PR TITLE
release: promote transparent Cortex logo

### DIFF
--- a/e2e/docs-ui.spec.ts
+++ b/e2e/docs-ui.spec.ts
@@ -33,20 +33,22 @@ test.describe('Docs UI', () => {
     });
   });
 
-  test('loads the Built by Cortex badge from the Worker', async ({ page }) => {
+  test('loads the transparent Built by Cortex logo inside a theme-aware card', async ({ page }) => {
     await page.goto('/docs/quickstart');
-    const badgeLink = page.getByRole('link', { name: 'Built by Cortex' });
-    const badgeImage = badgeLink.getByRole('img', { name: 'Built by Cortex' });
+    const logoCard = page.getByRole('link', { name: 'Built by Cortex' });
+    const logoImage = logoCard.getByRole('img', { name: 'Built by Cortex' });
 
-    await expect(badgeLink).toHaveAttribute('href', 'https://cortexdocs.dev');
-    await badgeLink.scrollIntoViewIfNeeded();
-    await expect(badgeImage).toHaveAttribute(
+    await expect(logoCard).toHaveAttribute('href', 'https://cortexdocs.dev');
+    await logoCard.scrollIntoViewIfNeeded();
+    await expect(logoCard).toHaveClass(/dark:bg-zinc-950/);
+    await expect(logoImage).toHaveAttribute(
       'src',
-      'http://localhost:4010/assets/built-by-cortex.svg',
+      'http://localhost:4010/images/built-by-cortex.svg',
     );
+    await expect(logoImage).toHaveClass(/dark:invert/);
     await expect
-      .poll(() => badgeImage.evaluate((image: HTMLImageElement) => image.naturalWidth))
-      .toBe(148);
+      .poll(() => logoImage.evaluate((image: HTMLImageElement) => image.naturalWidth))
+      .toBe(128);
   });
 
   test('shows authentication info', async ({ page }) => {

--- a/packages/demo-api/__tests__/worker.test.ts
+++ b/packages/demo-api/__tests__/worker.test.ts
@@ -12,8 +12,10 @@ describe('demo API Worker', () => {
     await expect(response.json()).resolves.toEqual({ status: 'ok', runtime: 'cloudflare-worker' });
   });
 
-  it('serves the Built by Cortex badge as a cached Cloudflare asset', async () => {
-    const response = await request('/assets/built-by-cortex.svg');
+  it('serves the transparent Built by Cortex logo as a cached Cloudflare asset', async () => {
+    const response = await worker.fetch(
+      new Request('https://static.cortexdocs.dev/images/built-by-cortex.svg'),
+    );
     const body = await response.text();
 
     expect(response.status).toBe(200);
@@ -21,7 +23,23 @@ describe('demo API Worker', () => {
     expect(response.headers.get('Cache-Control')).toContain('max-age=86400');
     expect(response.headers.get('Cross-Origin-Resource-Policy')).toBe('cross-origin');
     expect(body).toContain('<title id="title">Built by Cortex</title>');
-    expect(body).toContain('<svg');
+    expect(body).toContain('width="128" height="20"');
+    expect(body).not.toContain('<rect');
+  });
+
+  it('redirects the old badge URL to the static image host', async () => {
+    const response = await request('/assets/built-by-cortex.svg', { redirect: 'manual' });
+
+    expect(response.status).toBe(308);
+    expect(response.headers.get('Location')).toBe(
+      'https://static.cortexdocs.dev/images/built-by-cortex.svg',
+    );
+  });
+
+  it('does not expose demo API routes on the static image host', async () => {
+    const response = await worker.fetch(new Request('https://static.cortexdocs.dev/pets'));
+
+    expect(response.status).toBe(404);
   });
 
   it('returns the Petstore collection with CORS headers', async () => {

--- a/packages/demo-api/src/index.ts
+++ b/packages/demo-api/src/index.ts
@@ -108,16 +108,16 @@ const corsHeaders = {
   'Access-Control-Allow-Headers': 'Authorization, Content-Type',
 };
 
-const builtByCortexBadge = `<svg xmlns="http://www.w3.org/2000/svg" width="148" height="36" viewBox="0 0 148 36" role="img" aria-labelledby="title">
+const builtByCortexLogoUrl = 'https://static.cortexdocs.dev/images/built-by-cortex.svg';
+const builtByCortexLogo = `<svg xmlns="http://www.w3.org/2000/svg" width="128" height="20" viewBox="0 0 128 20" role="img" aria-labelledby="title">
   <title id="title">Built by Cortex</title>
-  <rect x="0.5" y="0.5" width="147" height="35" rx="9.5" fill="#0a0a0a" stroke="#ffffff" stroke-opacity="0.15"/>
-  <g transform="translate(7 8)" fill="none" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round">
+  <g transform="translate(0 0.5)" fill="none" stroke="#18181b" stroke-linecap="round" stroke-linejoin="round">
     <path d="M9 2.5Q11 1 13 2.5L18 5Q20 6 18 7L13 9.5Q11 11 9 9.5L4 7Q2 6 4 5L9 2.5Z" stroke-width="1.5" fill="#ffffff" fill-opacity="0.1"/>
     <path d="M3 10L9 13.5Q11 14.8 13 13.5L19 10" stroke-width="1.5"/>
     <path d="M3 13.5L9 17Q11 18.3 13 17L19 13.5" stroke-width="1.5" opacity="0.5"/>
   </g>
-  <text x="37" y="21.5" fill="#a1a1aa" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="11">Built by</text>
-  <text x="77" y="21.5" fill="#ffffff" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="11" font-weight="600">Cortex</text>
+  <text x="30" y="13.5" fill="#71717a" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="11">Built by</text>
+  <text x="70" y="13.5" fill="#18181b" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="11" font-weight="600">Cortex</text>
 </svg>`;
 
 function json(data: unknown, status = 200): Response {
@@ -136,8 +136,8 @@ function withCors(response: Response): Response {
   return new Response(response.body, { status: response.status, headers });
 }
 
-function builtByCortexBadgeResponse(method: string): Response {
-  return new Response(method === 'HEAD' ? null : builtByCortexBadge, {
+function builtByCortexLogoResponse(method: string): Response {
+  return new Response(method === 'HEAD' ? null : builtByCortexLogo, {
     headers: {
       ...corsHeaders,
       'Cache-Control': 'public, max-age=86400, stale-while-revalidate=604800',
@@ -351,8 +351,23 @@ async function handleRequest(request: Request): Promise<Response> {
 
   if (method === 'OPTIONS') return new Response(null, { status: 204, headers: corsHeaders });
 
+  if (path === '/images/built-by-cortex.svg' && (method === 'GET' || method === 'HEAD')) {
+    return builtByCortexLogoResponse(method);
+  }
+
   if (path === '/assets/built-by-cortex.svg' && (method === 'GET' || method === 'HEAD')) {
-    return builtByCortexBadgeResponse(method);
+    return new Response(null, {
+      status: 308,
+      headers: {
+        ...corsHeaders,
+        'Cache-Control': 'public, max-age=3600',
+        Location: builtByCortexLogoUrl,
+      },
+    });
+  }
+
+  if (url.hostname === 'static.cortexdocs.dev') {
+    return json({ code: 'not_found' }, 404);
   }
 
   if (request.headers.get('Upgrade')?.toLowerCase() === 'websocket') {

--- a/packages/demo-api/wrangler.jsonc
+++ b/packages/demo-api/wrangler.jsonc
@@ -5,16 +5,20 @@
   "compatibility_date": "2026-08-24",
   "compatibility_flags": ["nodejs_compat"],
   "alias": {
-    "graphql": "graphql/index.js"
+    "graphql": "graphql/index.js",
   },
   "workers_dev": false,
   "routes": [
     {
       "pattern": "api.demo.cortexdocs.dev",
-      "custom_domain": true
-    }
+      "custom_domain": true,
+    },
+    {
+      "pattern": "static.cortexdocs.dev",
+      "custom_domain": true,
+    },
   ],
   "observability": {
-    "enabled": true
-  }
+    "enabled": true,
+  },
 }

--- a/packages/docs-ui/app/docs/[slug]/page.tsx
+++ b/packages/docs-ui/app/docs/[slug]/page.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import { use, useEffect, useMemo, useRef, useState } from 'react';
-import Image from 'next/image';
 import Link from 'next/link';
 
+import { BuiltByCortexCard } from '@/components/docs/built-by-cortex-card';
 import { DocsBreadcrumb, type BreadcrumbSegment } from '@/components/docs/docs-breadcrumb';
 import { Card, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { cn } from '@/lib/utils';
@@ -14,10 +14,6 @@ interface TocItem {
   text: string;
   level: number;
 }
-
-const BUILT_BY_CORTEX_BADGE_URL =
-  process.env.NEXT_PUBLIC_CORTEX_BUILT_BY_BADGE_URL ??
-  'https://api.demo.cortexdocs.dev/assets/built-by-cortex.svg';
 
 function extractToc(html: string): TocItem[] {
   const items: TocItem[] = [];
@@ -254,21 +250,7 @@ export default function DocSlugPage({ params }: { params: Promise<{ slug: string
                 )}
                 {tocSpacer > 0 && <div style={{ height: tocSpacer }} aria-hidden="true" />}
                 <footer className="mt-12 flex justify-center pb-2">
-                  <a
-                    href="https://cortexdocs.dev"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    aria-label="Built by Cortex"
-                    className="inline-flex rounded-[10px] shadow-sm transition-opacity hover:opacity-85 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
-                  >
-                    <Image
-                      src={BUILT_BY_CORTEX_BADGE_URL}
-                      alt="Built by Cortex"
-                      width={148}
-                      height={36}
-                      unoptimized
-                    />
-                  </a>
+                  <BuiltByCortexCard />
                 </footer>
               </>
             ) : !data ? (

--- a/packages/docs-ui/components/docs/built-by-cortex-card.tsx
+++ b/packages/docs-ui/components/docs/built-by-cortex-card.tsx
@@ -1,0 +1,35 @@
+import Image from 'next/image';
+
+import { cn } from '@/lib/utils';
+
+const BUILT_BY_CORTEX_LOGO_URL =
+  process.env.NEXT_PUBLIC_CORTEX_BUILT_BY_LOGO_URL ??
+  process.env.NEXT_PUBLIC_CORTEX_BUILT_BY_BADGE_URL ??
+  'https://static.cortexdocs.dev/images/built-by-cortex.svg';
+
+export function BuiltByCortexCard({ className }: { className?: string }) {
+  return (
+    <a
+      href="https://cortexdocs.dev"
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label="Built by Cortex"
+      className={cn(
+        'inline-flex items-center rounded-[10px] border border-black/10 bg-white px-2.5 py-2 shadow-sm',
+        'transition-colors hover:border-black/15 hover:bg-zinc-50',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+        'dark:border-white/15 dark:bg-zinc-950 dark:hover:border-white/20 dark:hover:bg-zinc-900',
+        className,
+      )}
+    >
+      <Image
+        src={BUILT_BY_CORTEX_LOGO_URL}
+        alt="Built by Cortex"
+        width={128}
+        height={20}
+        className="h-5 w-32 transition-[filter] dark:invert"
+        unoptimized
+      />
+    </a>
+  );
+}

--- a/packages/docs-ui/next.config.js
+++ b/packages/docs-ui/next.config.js
@@ -13,15 +13,15 @@ module.exports = {
     remotePatterns: [
       {
         protocol: 'https',
-        hostname: 'api.demo.cortexdocs.dev',
+        hostname: 'static.cortexdocs.dev',
         port: '',
-        pathname: '/assets/built-by-cortex.svg',
+        pathname: '/images/built-by-cortex.svg',
         search: '',
       },
       {
         protocol: 'http',
         hostname: 'localhost',
-        pathname: '/assets/built-by-cortex.svg',
+        pathname: '/images/built-by-cortex.svg',
         search: '',
       },
     ],

--- a/packages/docs-ui/scripts/cloudflare.mjs
+++ b/packages/docs-ui/scripts/cloudflare.mjs
@@ -27,17 +27,16 @@ const wranglerConfig = resolve(
   docsUiDir,
   target === 'demo' ? 'wrangler.jsonc' : 'wrangler.docs-site.jsonc',
 );
-const badgeUrl =
+const builtByCortexLogoUrl =
+  process.env.CORTEX_BUILT_BY_LOGO_URL ||
   process.env.CORTEX_BUILT_BY_BADGE_URL ||
-  (target === 'demo'
-    ? `${demoApiUrl}/assets/built-by-cortex.svg`
-    : 'https://api.demo.cortexdocs.dev/assets/built-by-cortex.svg');
+  'https://static.cortexdocs.dev/images/built-by-cortex.svg';
 
 const env = {
   ...process.env,
   CORTEX_CLOUDFLARE: '1',
   NEXT_PUBLIC_CORTEX_CLOUDFLARE: '1',
-  NEXT_PUBLIC_CORTEX_BUILT_BY_BADGE_URL: badgeUrl,
+  NEXT_PUBLIC_CORTEX_BUILT_BY_LOGO_URL: builtByCortexLogoUrl,
   CORTEX_DIST_DIR: '.next',
   CORTEX_DOCS_UI_ROOT: docsUiDir,
   CORTEX_CONFIG_PATH: prepared.configPath,

--- a/packages/docs-ui/scripts/dev.mjs
+++ b/packages/docs-ui/scripts/dev.mjs
@@ -260,9 +260,10 @@ function startDocsServe() {
     cwd: TEST_PROJECT_DIR,
     env: {
       ...process.env,
-      NEXT_PUBLIC_CORTEX_BUILT_BY_BADGE_URL:
+      NEXT_PUBLIC_CORTEX_BUILT_BY_LOGO_URL:
+        process.env.NEXT_PUBLIC_CORTEX_BUILT_BY_LOGO_URL ||
         process.env.NEXT_PUBLIC_CORTEX_BUILT_BY_BADGE_URL ||
-        `http://localhost:${MOCK_PORT}/assets/built-by-cortex.svg`,
+        `http://localhost:${MOCK_PORT}/images/built-by-cortex.svg`,
     },
     detached: false,
     stdio: 'inherit',


### PR DESCRIPTION
## Summary
- promote the tested transparent Built by Cortex logo asset
- deploy `static.cortexdocs.dev/images/built-by-cortex.svg` with the demo Worker
- deploy the light/dark theme-aware card in the demo and product docs

## Source
- #18