### PR TITLE
docs: include MCP publishing details

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Cortex Docs
+Copyright (c) 2026 Cortex Docs
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ One project can combine OpenAPI, AsyncAPI, GraphQL, Protocol Buffer, and OpenRPC
 - Combine multiple specification files in one generated SDK.
 - Generate HTTP, WebSocket, GraphQL, gRPC, and JSON-RPC clients.
 - Generate a production documentation server with interactive API reference pages.
-- Generate MCP tools for REST, GraphQL, OpenRPC, and WebSocket payload preparation.
+- Generate MCP server for REST, GraphQL, OpenRPC, and WebSocket payload preparation.
 - Add Markdown pages, SDK guides, and all API specifications to the MCP server.
 - Customize generated output with sparse Eta template overrides.
-- Publish generated packages to language registries and GitHub repositories.
+- Publish generated packages and MCP to language registries and GitHub repositories.
 
 ## Requirements
 


### PR DESCRIPTION
## Summary
- update the license year to 2026
- clarify that Cortex generates an MCP server
- mention MCP publication in the README

## Release flow
This PR targets `pre-release` first. After CI passes and it is merged, `pre-release` will be promoted to `main`.