### PR TITLE
release: promote custom head HTML support

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ project: my-api
 title: My API Docs
 logo: ./assets/logo.svg
 theme: system
+custom_head_html: |-
+  <meta name="theme-color" content="#ffffff">
+  <link rel="stylesheet" href="/assets/custom.css">
 
 sources:
   - title: REST API
@@ -92,6 +95,12 @@ docs:
 mcp:
   package_name: '@my-org/my-api-mcp'
 ```
+
+`custom_head_html` adds trusted HTML to every documentation page. This field supports metadata, stylesheets, and analytics scripts.
+
+Store local head resources in the project `assets` directory. Cortex serves these files from `/assets/*`.
+
+Cortex does not sanitize this value. Add only HTML that you trust.
 
 Sources that use the same language and `package_name` are merged into one SDK. Cortex Docs rejects duplicate operation and type names that would make a merge ambiguous.
 

--- a/e2e/docs-ui.spec.ts
+++ b/e2e/docs-ui.spec.ts
@@ -33,6 +33,31 @@ test.describe('Docs UI', () => {
     });
   });
 
+  test('renders custom head HTML and serves project assets', async ({ page }) => {
+    await page.goto('/');
+
+    await expect(page.locator('head meta[name="theme-color"]')).toHaveAttribute(
+      'content',
+      '#ffffff',
+    );
+    await expect(page.locator('head link[href="/assets/custom.css"]')).toHaveAttribute(
+      'rel',
+      'stylesheet',
+    );
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          getComputedStyle(document.documentElement)
+            .getPropertyValue('--cortex-custom-head-loaded')
+            .trim(),
+        ),
+      )
+      .toBe('yes');
+    await expect
+      .poll(() => page.evaluate(() => document.documentElement.dataset.cortexCustomHead))
+      .toBe('loaded');
+  });
+
   test('loads the transparent Built with Cortex logo inside a theme-aware card', async ({
     page,
   }) => {

--- a/packages/codegen/__tests__/gql-codegen.test.ts
+++ b/packages/codegen/__tests__/gql-codegen.test.ts
@@ -167,6 +167,15 @@ describe('GraphQL Codegen — All Languages', () => {
         });
       }
 
+      if (language === 'php') {
+        it('reconnects when a GraphQL WebSocket sends a close frame', async () => {
+          const files = await generateForLanguage(language);
+          const client = getFile(files, 'gql-client')!;
+          expect(client.content).toContain('$opcode = ord($header[0]) & 0x0F;');
+          expect(client.content).toContain('if ($opcode === 0x8)');
+        });
+      }
+
       if (language === 'rust') {
         it('generates query/mutate/subscribe methods on client', async () => {
           const files = await generateForLanguage(language);

--- a/packages/codegen/src/languages/php/templates/graphql/client.ejs
+++ b/packages/codegen/src/languages/php/templates/graphql/client.ejs
@@ -209,6 +209,7 @@ class <%= it.clientClass %>
         if ($header === false || strlen($header) < 2) {
             return null;
         }
+        $opcode = ord($header[0]) & 0x0F;
         $len = ord($header[1]) & 0x7F;
         if ($len === 126) {
             $ext = fread($socket, 2);
@@ -233,6 +234,9 @@ class <%= it.clientClass %>
             for ($i = 0; $i < strlen($data); $i++) {
                 $data[$i] = $data[$i] ^ $mask[$i % 4];
             }
+        }
+        if ($opcode === 0x8) {
+            return null;
         }
         return $data;
     }

--- a/packages/core/__tests__/config-loader.test.ts
+++ b/packages/core/__tests__/config-loader.test.ts
@@ -478,11 +478,12 @@ describe('ConfigLoader', () => {
       expect(config.languages[0].github_repository).toBe('github.com/acme/sdk');
     });
 
-    it('puts title/logo/theme at root level', () => {
+    it('puts documentation site settings at root level', () => {
       const config = loader.validate({
         project: 'acme',
         title: 'Acme API',
         logo: './logo.png',
+        custom_head_html: '<meta name="theme-color" content="#ffffff">',
         theme: 'light',
         sources: [
           {
@@ -496,6 +497,7 @@ describe('ConfigLoader', () => {
 
       expect(config.title).toBe('Acme API');
       expect(config.logo).toBe('./logo.png');
+      expect(config.custom_head_html).toBe('<meta name="theme-color" content="#ffffff">');
       expect(config.theme).toBe('light');
     });
   });

--- a/packages/core/src/config/schema.ts
+++ b/packages/core/src/config/schema.ts
@@ -255,6 +255,7 @@ export const cortexConfigSchema = z
     logoHeight: z.number().positive().optional(),
     showLogoDocsLabel: z.boolean().optional(),
     favicon: z.string().optional(),
+    custom_head_html: z.string().optional(),
     theme: z.enum(['light', 'dark', 'system']).default('system'),
     primaryColor: z
       .string()

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -177,6 +177,7 @@ export interface CortexConfig {
   logoHeight?: number;
   showLogoDocsLabel?: boolean;
   favicon?: string;
+  custom_head_html?: string;
   theme?: 'light' | 'dark' | 'system';
   primaryColor?: string;
   home?: HomeConfig;

--- a/packages/docs-site/docs/configuration.md
+++ b/packages/docs-site/docs/configuration.md
@@ -16,6 +16,9 @@ title: My Project Documentation
 logo: ./assets/logo.svg
 theme: system
 primaryColor: '#ffffff'
+custom_head_html: |-
+  <meta name="theme-color" content="#ffffff">
+  <link rel="stylesheet" href="/assets/custom.css">
 
 sources:
   - title: 'REST API V1'
@@ -120,6 +123,7 @@ mcp:
 | `logoHeight`           | number  | No       | Logo height in pixels                                                                                                                                                                                                                                                                        |
 | `showLogoDocsLabel`    | boolean | No       | Show the `Docs` label next to the logo                                                                                                                                                                                                                                                       |
 | `favicon`              | string  | No       | Path to a custom favicon                                                                                                                                                                                                                                                                     |
+| `custom_head_html`     | string  | No       | Trusted HTML that Cortex adds to the `<head>` element on every documentation page                                                                                                                                                                                                            |
 | `theme`                | string  | No       | Color theme: `light`, `dark`, or `system` (default: `system`)                                                                                                                                                                                                                                |
 | `primaryColor`         | string  | No       | Brand accent color as a hex code (e.g. `"#01FFB2"`). Styles buttons, active nav icons, card tints, and hover accents. Automatically adjusts brightness per theme for readability — dark colors brighten on dark backgrounds, light colors deepen on light backgrounds (default: `"#ffffff"`) |
 | `sources`              | array   | Yes      | List of API spec sources (see below)                                                                                                                                                                                                                                                         |
@@ -131,6 +135,31 @@ mcp:
 | `publish`              | object  | No       | Package registry and GitHub publication settings                                                                                                                                                                                                                                             |
 
 See [Custom Generators](/docs/custom-generators) for export commands, template data, and override rules.
+
+## Custom Head HTML
+
+`custom_head_html` adds trusted HTML to the `<head>` element on every documentation page. The value can contain metadata, stylesheets, and analytics scripts.
+
+Files in the project `assets` directory are available under `/assets/*`.
+
+```yaml
+custom_head_html: |-
+  <meta name="theme-color" content="#ffffff">
+  <link rel="stylesheet" href="/assets/custom.css">
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXXXX"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-XXXXXXXXXX');
+  </script>
+```
+
+Replace `G-XXXXXXXXXX` with your Google Analytics measurement ID.
+
+CAUTION: Add only HTML that you trust. Scripts in this field can execute in every visitor's browser.
 
 ## Sources
 

--- a/packages/docs-ui/__tests__/project-assets.test.ts
+++ b/packages/docs-ui/__tests__/project-assets.test.ts
@@ -1,0 +1,67 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { GET } from '../app/assets/[...path]/route';
+
+const originalConfigPath = process.env.CORTEX_CONFIG_PATH;
+const temporaryDirectories: string[] = [];
+
+function createProject() {
+  const projectDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'cortex-assets-test-'));
+  temporaryDirectories.push(projectDirectory);
+  fs.mkdirSync(path.join(projectDirectory, 'assets'));
+  fs.writeFileSync(
+    path.join(projectDirectory, 'cortex.config.yml'),
+    'project: test\nsources: []\n',
+  );
+  process.env.CORTEX_CONFIG_PATH = path.join(projectDirectory, 'cortex.config.yml');
+  return projectDirectory;
+}
+
+function requestAsset(...segments: string[]) {
+  return GET(new Request(`http://localhost/assets/${segments.join('/')}`), {
+    params: Promise.resolve({ path: segments }),
+  });
+}
+
+afterEach(() => {
+  if (originalConfigPath === undefined) delete process.env.CORTEX_CONFIG_PATH;
+  else process.env.CORTEX_CONFIG_PATH = originalConfigPath;
+
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe('project assets', () => {
+  it('serves files from the configured project assets directory', async () => {
+    const projectDirectory = createProject();
+    fs.writeFileSync(path.join(projectDirectory, 'assets', 'custom.css'), ':root { color: red; }');
+
+    const response = await requestAsset('custom.css');
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toBe('text/css; charset=utf-8');
+    expect(await response.text()).toBe(':root { color: red; }');
+  });
+
+  it('does not serve files outside the project assets directory', async () => {
+    createProject();
+
+    const response = await requestAsset('..', 'cortex.config.yml');
+
+    expect(response.status).toBe(400);
+  });
+
+  it('does not follow symlinks outside the project assets directory', async () => {
+    const projectDirectory = createProject();
+    const privateFile = path.join(projectDirectory, 'private.txt');
+    fs.writeFileSync(privateFile, 'private');
+    fs.symlinkSync(privateFile, path.join(projectDirectory, 'assets', 'public.txt'));
+
+    const response = await requestAsset('public.txt');
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/packages/docs-ui/app/assets/[...path]/route.ts
+++ b/packages/docs-ui/app/assets/[...path]/route.ts
@@ -1,0 +1,67 @@
+import * as fs from 'node:fs';
+import * as nodePath from 'node:path';
+import { NextResponse } from 'next/server';
+
+const CONTENT_TYPES: Record<string, string> = {
+  '.css': 'text/css; charset=utf-8',
+  '.gif': 'image/gif',
+  '.ico': 'image/x-icon',
+  '.jpeg': 'image/jpeg',
+  '.jpg': 'image/jpeg',
+  '.js': 'text/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.mjs': 'text/javascript; charset=utf-8',
+  '.otf': 'font/otf',
+  '.png': 'image/png',
+  '.svg': 'image/svg+xml; charset=utf-8',
+  '.ttf': 'font/ttf',
+  '.txt': 'text/plain; charset=utf-8',
+  '.webmanifest': 'application/manifest+json; charset=utf-8',
+  '.webp': 'image/webp',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+  '.xml': 'application/xml; charset=utf-8',
+};
+
+export async function GET(_request: Request, { params }: { params: Promise<{ path: string[] }> }) {
+  const configPath = process.env.CORTEX_CONFIG_PATH;
+  if (!configPath) {
+    return NextResponse.json({ error: 'No project configuration was found.' }, { status: 404 });
+  }
+
+  const { path: segments } = await params;
+  if (
+    !Array.isArray(segments) ||
+    segments.length === 0 ||
+    segments.some(
+      (segment) =>
+        !segment ||
+        segment === '.' ||
+        segment === '..' ||
+        segment.includes('/') ||
+        segment.includes('\\') ||
+        segment.includes('\0'),
+    )
+  ) {
+    return NextResponse.json({ error: 'The asset path is not valid.' }, { status: 400 });
+  }
+
+  try {
+    const assetsRoot = fs.realpathSync(nodePath.join(nodePath.dirname(configPath), 'assets'));
+    const assetPath = fs.realpathSync(nodePath.join(assetsRoot, ...segments));
+    if (!assetPath.startsWith(`${assetsRoot}${nodePath.sep}`) || !fs.statSync(assetPath).isFile()) {
+      throw new Error('The asset path is outside the project asset directory.');
+    }
+
+    const extension = nodePath.extname(assetPath).toLowerCase();
+    return new NextResponse(fs.readFileSync(assetPath), {
+      headers: {
+        'Cache-Control': 'public, max-age=3600',
+        'Content-Type': CONTENT_TYPES[extension] ?? 'application/octet-stream',
+        'X-Content-Type-Options': 'nosniff',
+      },
+    });
+  } catch {
+    return NextResponse.json({ error: 'Asset file not found.' }, { status: 404 });
+  }
+}

--- a/packages/docs-ui/app/layout.tsx
+++ b/packages/docs-ui/app/layout.tsx
@@ -5,9 +5,26 @@ import { GeistSans } from 'geist/font/sans';
 import { GeistMono } from 'geist/font/mono';
 import type { Metadata } from 'next';
 import { ThemeProvider } from '@/components/docs/theme-provider';
-import { SiteConfigProvider, type HomeSection } from '@/components/docs/site-config-provider';
+import {
+  SiteConfigProvider,
+  type HomeSection,
+  type SiteConfig,
+} from '@/components/docs/site-config-provider';
 import { SearchProvider } from '@/components/docs/search-provider';
 import { sanitizeSvg } from '@/lib/sanitize-svg';
+
+interface LoadedSiteConfig extends SiteConfig {
+  customHeadHtml?: string;
+}
+
+function emptySiteConfig(): LoadedSiteConfig {
+  return {
+    title: '',
+    project: '',
+    hasLogo: false,
+    customHeadHtml: undefined,
+  };
+}
 
 function adj(r: number, g: number, b: number, mul: number) {
   return `rgb(${Math.min(255, Math.round(r * mul))},${Math.min(255, Math.round(g * mul))},${Math.min(255, Math.round(b * mul))})`;
@@ -36,7 +53,7 @@ function parsePrimary(hex: string) {
   return { lightColor, darkColor, lightFg, darkFg, lightText, darkText, cardTint };
 }
 
-function readSiteConfig() {
+function readSiteConfig(): LoadedSiteConfig {
   let configFile: string | null = null;
   let dir: string | null = null;
 
@@ -48,7 +65,7 @@ function readSiteConfig() {
 
   if (!configFile) {
     const specPath = process.env.CORTEX_SPEC_PATH;
-    if (!specPath) return { title: '', project: '', hasLogo: false };
+    if (!specPath) return emptySiteConfig();
     dir = path.dirname(specPath);
     for (const name of ['cortex.config.yml', 'cortex.config.yaml', 'cortex.yml']) {
       const candidate = path.join(dir, name);
@@ -59,7 +76,7 @@ function readSiteConfig() {
     }
   }
 
-  if (!configFile || !dir) return { title: '', project: '', hasLogo: false };
+  if (!configFile || !dir) return emptySiteConfig();
 
   try {
     const yaml = require('js-yaml');
@@ -104,6 +121,11 @@ function readSiteConfig() {
     const sources = raw?.sources as Array<unknown> | undefined;
     const docs = raw?.docs as Array<unknown> | undefined;
     const mcp = raw?.mcp as Record<string, unknown> | undefined;
+    const customHeadHtmlValue = raw?.custom_head_html;
+    const customHeadHtml =
+      typeof customHeadHtmlValue === 'string' && customHeadHtmlValue.trim()
+        ? customHeadHtmlValue
+        : undefined;
     return {
       title: (raw?.title as string) ?? '',
       project: (raw?.project as string) ?? '',
@@ -114,6 +136,7 @@ function readSiteConfig() {
       logoHeight: (raw?.logoHeight as number) ?? undefined,
       showLogoDocsLabel: (raw?.showLogoDocsLabel as boolean) ?? true,
       favicon,
+      customHeadHtml,
       primaryColor,
       theme,
       hasSources: Array.isArray(sources) && sources.length > 0,
@@ -129,7 +152,7 @@ function readSiteConfig() {
         : undefined,
     };
   } catch {
-    return { title: '', project: '', hasLogo: false };
+    return emptySiteConfig();
   }
 }
 
@@ -141,11 +164,12 @@ export function generateMetadata(): Metadata {
   return {
     title,
     description: siteConfig.home?.description || `API documentation for ${title}`,
+    icons: siteConfig.favicon ? { icon: siteConfig.favicon } : undefined,
   };
 }
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
-  const siteConfig = readSiteConfig();
+  const { customHeadHtml, ...siteConfig } = readSiteConfig();
 
   const pc = siteConfig.primaryColor;
   const primaryCss = pc
@@ -161,7 +185,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       className={`${GeistSans.variable} ${GeistMono.variable}`}
       suppressHydrationWarning
     >
-      <head>{siteConfig.favicon && <link rel="icon" href={siteConfig.favicon} />}</head>
+      {customHeadHtml && <head dangerouslySetInnerHTML={{ __html: customHeadHtml }} />}
       <body suppressHydrationWarning>
         {primaryCss && <style data-primary="" dangerouslySetInnerHTML={{ __html: primaryCss }} />}
         <SiteConfigProvider config={siteConfig}>

--- a/packages/docs-ui/scripts/dev.mjs
+++ b/packages/docs-ui/scripts/dev.mjs
@@ -91,11 +91,29 @@ function initTestProject() {
     writeFileSync(openRpcPath, `${JSON.stringify(document, null, 2)}\n`, 'utf-8');
   }
 
-  const configContent = readFileSync(configPath, 'utf-8').replace(
+  let configContent = readFileSync(configPath, 'utf-8').replace(
     /endpoint:\s*https?:\/\/[^\n]+\/graphql/,
     `endpoint: ${apiUrl}/graphql`,
   );
+  if (!configContent.includes('\ncustom_head_html:')) {
+    configContent = configContent.replace(
+      /^home:/m,
+      [
+        'custom_head_html: |-',
+        '  <meta name="theme-color" content="#ffffff">',
+        '  <link rel="stylesheet" href="/assets/custom.css">',
+        "  <script>document.documentElement.dataset.cortexCustomHead = 'loaded';</script>",
+        'home:',
+      ].join('\n'),
+    );
+  }
   writeFileSync(configPath, configContent, 'utf-8');
+  mkdirSync(join(TEST_PROJECT_DIR, 'assets'), { recursive: true });
+  writeFileSync(
+    join(TEST_PROJECT_DIR, 'assets', 'custom.css'),
+    ':root { --cortex-custom-head-loaded: yes; }\n',
+    'utf-8',
+  );
   log('init', `Configured demo endpoints for ${apiUrl}`);
 }
 

--- a/packages/docs-ui/scripts/prepare-demo.mjs
+++ b/packages/docs-ui/scripts/prepare-demo.mjs
@@ -62,6 +62,11 @@ export function prepareDemo(apiUrl = process.env.CORTEX_DEMO_API_URL || 'http://
 
   cpSync(join(docsSiteDir, 'assets'), join(demoDir, 'assets'), { recursive: true });
   cpSync(join(docsSiteDir, 'docs'), join(demoDir, 'docs'), { recursive: true });
+  writeFileSync(
+    join(demoDir, 'assets', 'custom.css'),
+    ':root { --cortex-custom-head-loaded: yes; }\n',
+    'utf8',
+  );
 
   const languages = sourceLanguages();
   const config = {
@@ -72,6 +77,11 @@ export function prepareDemo(apiUrl = process.env.CORTEX_DEMO_API_URL || 'http://
     logoHeight: 24,
     showLogoDocsLabel: true,
     favicon: './assets/favicon.svg',
+    custom_head_html: [
+      '<meta name="theme-color" content="#ffffff">',
+      '<link rel="stylesheet" href="/assets/custom.css">',
+      "<script>document.documentElement.dataset.cortexCustomHead = 'loaded';</script>",
+    ].join('\n'),
     theme: 'system',
     primaryColor: '#ffffff',
     home: {


### PR DESCRIPTION
## Summary

- promote `custom_head_html` configuration support
- render trusted metadata, stylesheets, and analytics scripts in docs pages
- serve project assets securely from `/assets/*`
- publish the README and docs-site configuration guidance

## Source

- #25

## Validation

- feature PR quality and browser checks passed
- production promotion runs quality, browser, SDK integration, and publish integration checks