### PR TITLE
fix(php): reconnect after GraphQL close frames

### DIFF
--- a/packages/codegen/__tests__/gql-codegen.test.ts
+++ b/packages/codegen/__tests__/gql-codegen.test.ts
@@ -167,6 +167,15 @@ describe('GraphQL Codegen — All Languages', () => {
         });
       }
 
+      if (language === 'php') {
+        it('reconnects when a GraphQL WebSocket sends a close frame', async () => {
+          const files = await generateForLanguage(language);
+          const client = getFile(files, 'gql-client')!;
+          expect(client.content).toContain('$opcode = ord($header[0]) & 0x0F;');
+          expect(client.content).toContain('if ($opcode === 0x8)');
+        });
+      }
+
       if (language === 'rust') {
         it('generates query/mutate/subscribe methods on client', async () => {
           const files = await generateForLanguage(language);

--- a/packages/codegen/src/languages/php/templates/graphql/client.ejs
+++ b/packages/codegen/src/languages/php/templates/graphql/client.ejs
@@ -209,6 +209,7 @@ class <%= it.clientClass %>
         if ($header === false || strlen($header) < 2) {
             return null;
         }
+        $opcode = ord($header[0]) & 0x0F;
         $len = ord($header[1]) & 0x7F;
         if ($len === 126) {
             $ext = fread($socket, 2);
@@ -233,6 +234,9 @@ class <%= it.clientClass %>
             for ($i = 0; $i < strlen($data); $i++) {
                 $data[$i] = $data[$i] ^ $mask[$i % 4];
             }
+        }
+        if ($opcode === 0x8) {
+            return null;
         }
         return $data;
     }


### PR DESCRIPTION
## Summary

- detect WebSocket close opcodes in the generated PHP GraphQL frame reader
- return immediately to the existing reconnect loop instead of blocking until the subscription deadline
- add generated-client regression coverage

## Root cause

The GraphQL frame reader treated close-frame payloads as application data. After the CI fault injector closed the first subscription, PHP waited on the closed connection until the deadline. This prevented the configured reconnect attempts from running and produced an empty upgrade error.

## Validation

- reproduced the failure with `TEST_LANGUAGES=php CORTEX_CI_IMAGE=cortex-ci-local:latest npm run test:sdk:ci`
- patched run: 28 PHP protocol tests passed with 88 assertions
- PHP transport resilience passed
- GraphQL code generation tests: 122 passed