### PR TITLE
Promote pre-release to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/cortex-docs/cortex/actions/workflows/ci.yml/badge.svg)](https://github.com/cortex-docs/cortex/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-Cortex Docs generates typed SDKs, interactive API documentation, and Model Context Protocol (MCP) servers from API specifications and custom markdown docs.
+Cortex turns API specifications and Markdown into typed SDKs, interactive documentation, and MCP servers for developers and AI agents.
 
 One project can combine OpenAPI, AsyncAPI, GraphQL, Protocol Buffer, and OpenRPC sources. Cortex Docs generates one package for each configured language.
 
@@ -101,6 +101,10 @@ mcp:
 Store local head resources in the project `assets` directory. Cortex serves these files from `/assets/*`.
 
 Cortex does not sanitize this value. Add only HTML that you trust.
+
+Add `?appearance=dark` or `?appearance=light` to any documentation URL to select its initial appearance. The parameter takes priority over the project theme and the visitor's stored preference.
+
+For example, `/docs/quickstart?appearance=dark` opens the quickstart in dark mode. The theme button can change the appearance after the page loads.
 
 Sources that use the same language and `package_name` are merged into one SDK. Cortex Docs rejects duplicate operation and type names that would make a merge ambiguous.
 

--- a/e2e/docs-ui.spec.ts
+++ b/e2e/docs-ui.spec.ts
@@ -100,6 +100,31 @@ test.describe('Docs UI', () => {
     await expect(html).toHaveClass(/light|^(?!.*dark)/);
   });
 
+  test('appearance query selects dark mode on a nested docs route', async ({ page }) => {
+    await page.goto('/');
+    await page.evaluate(() => localStorage.setItem('theme', 'light'));
+
+    await page.goto('/docs/quickstart?appearance=dark');
+
+    await expect(page.locator('html')).toHaveClass(/dark/);
+    await expect
+      .poll(() => page.evaluate(() => document.documentElement.style.colorScheme))
+      .toBe('dark');
+  });
+
+  test('appearance query selects light mode on an API route', async ({ page }) => {
+    await page.goto('/');
+    await page.evaluate(() => localStorage.setItem('theme', 'dark'));
+
+    await page.goto('/api-reference?source=embed&appearance=light');
+
+    await expect(page.locator('html')).toHaveClass(/light/);
+    await expect(page.locator('html')).not.toHaveClass(/dark/);
+    await expect
+      .poll(() => page.evaluate(() => document.documentElement.style.colorScheme))
+      .toBe('light');
+  });
+
   test('API spec endpoint returns valid content', async ({ request }) => {
     const response = await request.get('/api/spec');
     expect(response.ok()).toBeTruthy();

--- a/packages/docs-site/docs/configuration.md
+++ b/packages/docs-site/docs/configuration.md
@@ -136,6 +136,19 @@ mcp:
 
 See [Custom Generators](/docs/custom-generators) for export commands, template data, and override rules.
 
+## Appearance Query Parameter
+
+Add `?appearance=dark` or `?appearance=light` to any documentation URL. The parameter selects the initial appearance for that page.
+
+```text
+/docs/quickstart?appearance=dark
+/api-reference?appearance=light
+```
+
+The parameter takes priority over the project `theme` value and the visitor's stored preference. The theme button can change the appearance after the page loads.
+
+Cortex ignores other `appearance` values.
+
 ## Custom Head HTML
 
 `custom_head_html` adds trusted HTML to the `<head>` element on every documentation page. The value can contain metadata, stylesheets, and analytics scripts.

--- a/packages/docs-ui/__tests__/theme.test.ts
+++ b/packages/docs-ui/__tests__/theme.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { getAppearanceFromSearch } from '../components/docs/theme-provider';
+
+describe('docs appearance query parameter', () => {
+  it('accepts light and dark appearances in any query position', () => {
+    expect(getAppearanceFromSearch('?appearance=light')).toBe('light');
+    expect(getAppearanceFromSearch('?tab=overview&appearance=dark&source=nav')).toBe('dark');
+  });
+
+  it('ignores missing, invalid, and case-mismatched appearances', () => {
+    expect(getAppearanceFromSearch('')).toBeUndefined();
+    expect(getAppearanceFromSearch('?appearance=system')).toBeUndefined();
+    expect(getAppearanceFromSearch('?appearance=Dark')).toBeUndefined();
+  });
+});

--- a/packages/docs-ui/app/layout.tsx
+++ b/packages/docs-ui/app/layout.tsx
@@ -53,6 +53,10 @@ function parsePrimary(hex: string) {
   return { lightColor, darkColor, lightFg, darkFg, lightText, darkText, cardTint };
 }
 
+function createThemeInitializationScript(defaultTheme: 'light' | 'dark' | 'system'): string {
+  return `(()=>{try{const e=document.documentElement,p=new URLSearchParams(location.search).get("appearance");let t=p==="light"||p==="dark"?p:"";if(!t){try{const s=localStorage.getItem("theme");if(s==="light"||s==="dark"||s==="system")t=s}catch{}}if(!t)t="${defaultTheme}";const r=t==="system"?(matchMedia("(prefers-color-scheme: dark)").matches?"dark":"light"):t;e.classList.remove("light","dark");e.classList.add(r);e.style.colorScheme=r}catch{}})();`;
+}
+
 function readSiteConfig(): LoadedSiteConfig {
   let configFile: string | null = null;
   let dir: string | null = null;
@@ -170,6 +174,7 @@ export function generateMetadata(): Metadata {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   const { customHeadHtml, ...siteConfig } = readSiteConfig();
+  const defaultTheme = siteConfig.theme ?? 'system';
 
   const pc = siteConfig.primaryColor;
   const primaryCss = pc
@@ -187,9 +192,13 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     >
       {customHeadHtml && <head dangerouslySetInnerHTML={{ __html: customHeadHtml }} />}
       <body suppressHydrationWarning>
+        <script
+          data-cortex-theme-init=""
+          dangerouslySetInnerHTML={{ __html: createThemeInitializationScript(defaultTheme) }}
+        />
         {primaryCss && <style data-primary="" dangerouslySetInnerHTML={{ __html: primaryCss }} />}
         <SiteConfigProvider config={siteConfig}>
-          <ThemeProvider defaultTheme={siteConfig.theme ?? 'system'} disableTransitionOnChange>
+          <ThemeProvider defaultTheme={defaultTheme} disableTransitionOnChange>
             <SearchProvider>{children}</SearchProvider>
           </ThemeProvider>
         </SiteConfigProvider>

--- a/packages/docs-ui/components/docs/theme-provider.tsx
+++ b/packages/docs-ui/components/docs/theme-provider.tsx
@@ -6,12 +6,18 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
   type ReactNode,
 } from 'react';
 
 export type Theme = 'light' | 'dark' | 'system';
 type ResolvedTheme = Exclude<Theme, 'system'>;
+
+export function getAppearanceFromSearch(search: string): ResolvedTheme | undefined {
+  const appearance = new URLSearchParams(search).get('appearance');
+  return appearance === 'light' || appearance === 'dark' ? appearance : undefined;
+}
 
 interface ThemeContextValue {
   theme: Theme;
@@ -61,6 +67,7 @@ export function ThemeProvider({
 }: ThemeProviderProps) {
   const [theme, setThemeState] = useState<Theme>(defaultTheme);
   const [resolvedTheme, setResolvedTheme] = useState<ResolvedTheme>();
+  const initializedTheme = useRef(false);
 
   const setTheme = useCallback((nextTheme: Theme) => {
     setThemeState(nextTheme);
@@ -70,18 +77,26 @@ export function ThemeProvider({
   }, []);
 
   useEffect(() => {
-    try {
-      const storedTheme = localStorage.getItem('theme');
-      if (storedTheme === 'light' || storedTheme === 'dark' || storedTheme === 'system') {
-        setThemeState(storedTheme);
-      }
-    } catch {}
-  }, []);
-
-  useEffect(() => {
     const media = window.matchMedia('(prefers-color-scheme: dark)');
+    let activeTheme = theme;
+
+    if (!initializedTheme.current) {
+      initializedTheme.current = true;
+      const appearance = getAppearanceFromSearch(window.location.search);
+      let storedTheme: Theme | undefined;
+      try {
+        const storedValue = localStorage.getItem('theme');
+        if (storedValue === 'light' || storedValue === 'dark' || storedValue === 'system') {
+          storedTheme = storedValue;
+        }
+      } catch {}
+
+      activeTheme = appearance ?? storedTheme ?? defaultTheme;
+      if (activeTheme !== theme) setThemeState(activeTheme);
+    }
+
     const updateTheme = () => {
-      const nextTheme = theme === 'system' ? getSystemTheme() : theme;
+      const nextTheme = activeTheme === 'system' ? getSystemTheme() : activeTheme;
       setResolvedTheme(nextTheme);
       applyTheme(nextTheme, disableTransitionOnChange);
     };
@@ -89,7 +104,7 @@ export function ThemeProvider({
     updateTheme();
     media.addEventListener('change', updateTheme);
     return () => media.removeEventListener('change', updateTheme);
-  }, [disableTransitionOnChange, theme]);
+  }, [defaultTheme, disableTransitionOnChange, theme]);
 
   const value = useMemo(
     () => ({ theme, resolvedTheme, setTheme }),


### PR DESCRIPTION
## Summary
- promote `appearance=dark` and `appearance=light` support to production
- preserve the existing theme toggle while overriding initial config/stored preferences
- publish the README and docs-site parameter reference

## Promotion
Feature PR: #28