### PR TITLE
fix(deploy): remove unsupported Worker CPU limits

### DIFF
--- a/packages/docs-ui/wrangler.docs-site.jsonc
+++ b/packages/docs-ui/wrangler.docs-site.jsonc
@@ -27,9 +27,6 @@
   "observability": {
     "enabled": true,
   },
-  "limits": {
-    "cpu_ms": 300000,
-  },
   "vars": {
     "NEXTJS_ENV": "production",
     "CORTEX_CLOUDFLARE": "1",

--- a/packages/docs-ui/wrangler.jsonc
+++ b/packages/docs-ui/wrangler.jsonc
@@ -27,9 +27,6 @@
   "observability": {
     "enabled": true,
   },
-  "limits": {
-    "cpu_ms": 300000
-  },
   "vars": {
     "NEXTJS_ENV": "production",
     "CORTEX_CLOUDFLARE": "1",


### PR DESCRIPTION
Removes the explicit CPU limits rejected by Cloudflare Workers Free plan (API code 100328). OpenNext static caching and prerendering remain enabled.\n\nThis is the exact six-line production config change already validated in PR #32, reapplied on the synchronized pre-release head so GitHub squash history cannot neutralize it.