### PR TITLE
Fix packaged CLI E2E and API reference sidebar layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,20 @@ The project uses Semantic Versioning. Each release contains the same three chang
 
 - None.
 
+## [0.1.16] - 2026-08-25
+
+### New Features
+
+- None.
+
+### Bug Fixes
+
+- Fixed the demo docs Cloudflare Worker deployment by removing a CPU time limit setting that is unsupported on the Cloudflare Workers Free plan, which was blocking deployment.
+
+### Improvements
+
+- None.
+
 ## [0.1.15] - 2026-08-25
 
 ### New Features

--- a/e2e/docs-ui.spec.ts
+++ b/e2e/docs-ui.spec.ts
@@ -17,6 +17,27 @@ test.describe('Docs UI', () => {
     await expect(page.locator('text=Create a pet').first()).toBeVisible();
   });
 
+  test('moves only the right sidebar below when the projected center reaches 280px', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 932, height: 900 });
+    await page.goto('/api-reference');
+    await expect(page.locator('text=List all pets').first()).toBeVisible({ timeout: 15000 });
+
+    const leftSidebar = page.locator('[data-api-reference-left-sidebar]');
+    const rightSidebar = page.locator('[data-api-reference-right-sidebar]');
+    const bottomCodePanel = page.locator('[data-api-reference-bottom-code-panel]');
+
+    await expect(leftSidebar).toHaveAttribute('data-layout-mode', 'inline');
+    await expect(rightSidebar).toHaveCount(0);
+    await expect(bottomCodePanel).toBeVisible();
+
+    await page.setViewportSize({ width: 933, height: 900 });
+    await expect(leftSidebar).toHaveAttribute('data-layout-mode', 'inline');
+    await expect(rightSidebar).toBeVisible();
+    await expect(bottomCodePanel).toHaveCount(0);
+  });
+
   test('displays server URL', async ({ page }) => {
     await page.goto('/api-reference');
     await expect(page.locator('text=http://localhost:4010').first()).toBeVisible({

--- a/package-lock.json
+++ b/package-lock.json
@@ -19807,7 +19807,7 @@
     },
     "packages/cli": {
       "name": "@cortex-docs/cli",
-      "version": "0.1.15",
+      "version": "0.1.16",
       "bundleDependencies": [
         "@cortex-docs/core",
         "@cortex-docs/codegen",
@@ -19896,9 +19896,9 @@
     },
     "packages/docs-site": {
       "name": "@cortex-docs/docs-site",
-      "version": "0.1.15",
+      "version": "0.1.16",
       "dependencies": {
-        "@cortex-docs/cli": "0.1.15"
+        "@cortex-docs/cli": "0.1.16"
       }
     },
     "packages/docs-ui": {

--- a/packages/cli/__tests__/docs-runtime.test.ts
+++ b/packages/cli/__tests__/docs-runtime.test.ts
@@ -27,7 +27,7 @@ describe('docs runtime', () => {
     );
   });
 
-  it('isolates writable Next.js metadata from the packaged docs UI', () => {
+  it('copies development sources into the writable Next.js runtime', () => {
     const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'cortex-docs-runtime-'));
     const docsUiPath = path.join(workspace, 'docs-ui');
     const runtimeDir = path.join(docsUiPath, '.cortex-dev-test');
@@ -50,16 +50,14 @@ describe('docs runtime', () => {
     fs.writeFileSync(path.join(runtimeDir, 'next-env.d.ts'), 'runtime-only');
 
     expect(fs.statSync(path.join(runtimeDir, 'app')).isDirectory()).toBe(true);
-    expect(fs.realpathSync(path.join(runtimeDir, 'app', 'page.tsx'))).toBe(
-      fs.realpathSync(path.join(docsUiPath, 'app', 'page.tsx')),
-    );
+    expect(fs.lstatSync(path.join(runtimeDir, 'app', 'page.tsx')).isSymbolicLink()).toBe(false);
     expect(fs.readFileSync(path.join(docsUiPath, 'next-env.d.ts'), 'utf-8')).toBe('next-env.d.ts');
     expect(fs.readFileSync(path.join(runtimeDir, 'next-env.d.ts'), 'utf-8')).toBe('runtime-only');
 
     fs.rmSync(workspace, { recursive: true });
   });
 
-  it('adds renamed source files and removes their stale runtime links', () => {
+  it('updates changed source files and removes stale runtime files', () => {
     const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'cortex-docs-runtime-'));
     const docsUiPath = path.join(workspace, 'docs-ui');
     const runtimeDir = path.join(docsUiPath, '.cortex-dev-test');
@@ -81,11 +79,12 @@ describe('docs runtime', () => {
 
     prepareDocsUiRuntime(docsUiPath, runtimeDir);
     fs.renameSync(oldSource, newSource);
+    fs.writeFileSync(newSource, 'export const Card = "new";');
     syncDocsUiRuntimeSources(docsUiPath, runtimeDir);
 
     expect(fs.existsSync(path.join(runtimeDir, 'components', 'old-card.tsx'))).toBe(false);
-    expect(fs.realpathSync(path.join(runtimeDir, 'components', 'new-card.tsx'))).toBe(
-      fs.realpathSync(newSource),
+    expect(fs.readFileSync(path.join(runtimeDir, 'components', 'new-card.tsx'), 'utf-8')).toBe(
+      'export const Card = "new";',
     );
 
     fs.rmSync(workspace, { recursive: true });

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cortex-docs/cli",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "Cortex Docs CLI for SDKs, API documentation, and MCP servers",
   "license": "MIT",
   "repository": {

--- a/packages/cli/src/commands/docs/runtime.ts
+++ b/packages/cli/src/commands/docs/runtime.ts
@@ -20,7 +20,7 @@ export function resolveDevRuntimeDirName(projectDir: string): string {
 }
 
 export function prepareDocsUiRuntime(docsUiPath: string, runtimeDir: string): void {
-  prepareDocsUiRuntimeWithOptions(docsUiPath, runtimeDir);
+  prepareDocsUiRuntimeWithOptions(docsUiPath, runtimeDir, { copySources: true });
 }
 
 export function prepareDocsUiBuildRuntime(docsUiPath: string, runtimeDir: string): void {
@@ -55,31 +55,32 @@ export function syncDocsUiRuntimeSources(docsUiPath: string, runtimeDir: string)
   for (const name of RUNTIME_DIRECTORIES) {
     const source = path.join(docsUiPath, name);
     const target = path.join(runtimeDir, name);
-    if (fs.existsSync(target) && fs.lstatSync(target).isSymbolicLink()) {
-      fs.unlinkSync(target);
-    }
-    mirrorSourceDirectory(source, target);
+    syncSourceDirectory(source, target);
   }
 }
 
-function mirrorSourceDirectory(source: string, target: string): void {
+function syncSourceDirectory(source: string, target: string): void {
   fs.mkdirSync(target, { recursive: true });
 
   for (const entry of fs.readdirSync(target, { withFileTypes: true })) {
     const sourceEntry = path.join(source, entry.name);
     const targetEntry = path.join(target, entry.name);
-    if (entry.isSymbolicLink() && !fs.existsSync(sourceEntry)) {
-      fs.unlinkSync(targetEntry);
-    }
+    if (!fs.existsSync(sourceEntry)) fs.rmSync(targetEntry, { recursive: true, force: true });
   }
 
   for (const entry of fs.readdirSync(source, { withFileTypes: true })) {
     const sourceEntry = path.join(source, entry.name);
     const targetEntry = path.join(target, entry.name);
     if (entry.isDirectory()) {
-      mirrorSourceDirectory(sourceEntry, targetEntry);
-    } else if (!fs.existsSync(targetEntry)) {
-      fs.symlinkSync(sourceEntry, targetEntry, 'file');
+      if (fs.existsSync(targetEntry) && !fs.statSync(targetEntry).isDirectory()) {
+        fs.rmSync(targetEntry, { recursive: true, force: true });
+      }
+      syncSourceDirectory(sourceEntry, targetEntry);
+    } else {
+      if (fs.existsSync(targetEntry) && fs.statSync(targetEntry).isDirectory()) {
+        fs.rmSync(targetEntry, { recursive: true, force: true });
+      }
+      fs.copyFileSync(sourceEntry, targetEntry);
     }
   }
 }

--- a/packages/cli/src/commands/docs/serve.command.ts
+++ b/packages/cli/src/commands/docs/serve.command.ts
@@ -158,11 +158,15 @@ export class DocsServeCommand extends CommandRunner {
 
     const nextBinResolved = resolveNextBin(docsUiPath);
 
-    const child = spawn(process.execPath, [nextBinResolved, 'dev', '--port', String(port)], {
-      cwd: runtimeDir,
-      env,
-      stdio: 'inherit',
-    });
+    const child = spawn(
+      process.execPath,
+      [nextBinResolved, 'dev', '--webpack', '--port', String(port)],
+      {
+        cwd: runtimeDir,
+        env,
+        stdio: 'inherit',
+      },
+    );
 
     let debounce: ReturnType<typeof setTimeout> | null = null;
     let runtimeSyncDebounce: ReturnType<typeof setTimeout> | null = null;

--- a/packages/docs-site/package.json
+++ b/packages/docs-site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cortex-docs/docs-site",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "private": true,
   "description": "Product documentation for Cortex Docs",
   "scripts": {
@@ -9,6 +9,6 @@
     "clean": "rm -rf .cortex"
   },
   "dependencies": {
-    "@cortex-docs/cli": "0.1.15"
+    "@cortex-docs/cli": "0.1.16"
   }
 }

--- a/packages/docs-ui/__tests__/api-reference-layout.test.ts
+++ b/packages/docs-ui/__tests__/api-reference-layout.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { getApiReferencePanelVisibility } from '../lib/api-reference-layout';
+
+const widths = {
+  leftSidebarWidth: 224,
+  rightSidebarWidth: 420,
+};
+
+describe('API reference responsive layout', () => {
+  it('hides the right sidebar when the desktop center panel is exactly 280px wide', () => {
+    const visibility = getApiReferencePanelVisibility({ ...widths, layoutWidth: 932 });
+
+    expect(visibility).toEqual({
+      centerWidthWithRightSidebar: 280,
+      showLeftSidebarInline: true,
+      showRightSidebar: false,
+    });
+  });
+
+  it('keeps the right sidebar when the desktop center panel is 281px wide', () => {
+    expect(getApiReferencePanelVisibility({ ...widths, layoutWidth: 933 })).toEqual({
+      centerWidthWithRightSidebar: 281,
+      showLeftSidebarInline: true,
+      showRightSidebar: true,
+    });
+  });
+
+  it('keeps the left sidebar inline after the right sidebar moves to the bottom', () => {
+    const visibility = getApiReferencePanelVisibility({ ...widths, layoutWidth: 700 });
+
+    expect(visibility.showLeftSidebarInline).toBe(true);
+    expect(visibility.showRightSidebar).toBe(false);
+  });
+
+  it('only moves the left sidebar off canvas when its center panel reaches 280px', () => {
+    expect(
+      getApiReferencePanelVisibility({ ...widths, layoutWidth: 508 }).showLeftSidebarInline,
+    ).toBe(false);
+    expect(
+      getApiReferencePanelVisibility({ ...widths, layoutWidth: 509 }).showLeftSidebarInline,
+    ).toBe(true);
+  });
+});

--- a/packages/docs-ui/components/docs/sdk-reference.tsx
+++ b/packages/docs-ui/components/docs/sdk-reference.tsx
@@ -16,6 +16,7 @@ import hljsCpp from 'highlight.js/lib/languages/cpp';
 import hljsC from 'highlight.js/lib/languages/c';
 import hljsJson from 'highlight.js/lib/languages/json';
 import { cn } from '@/lib/utils';
+import { getApiReferencePanelVisibility } from '@/lib/api-reference-layout';
 import { TryNowModal, type TryNowConfig } from './try-now-modal';
 import { DocsBreadcrumb } from './docs-breadcrumb';
 
@@ -664,7 +665,7 @@ function ResizeHandle({
   return (
     <div
       onMouseDown={handleMouseDown}
-      className="hidden lg:flex w-3 -mx-1 shrink-0 cursor-col-resize items-center justify-center group/handle z-10"
+      className="flex w-3 -mx-1 shrink-0 cursor-col-resize items-center justify-center group/handle z-10"
     >
       <div className="h-full w-px transition-colors group-hover/handle:bg-border group-active/handle:bg-primary/40" />
     </div>
@@ -684,6 +685,11 @@ export function SdkReference({ scrollTarget }: { scrollTarget?: string[] }) {
   const [tryNowOpen, setTryNowOpen] = useState(false);
   const [leftWidth, setLeftWidth] = useState(224);
   const [rightWidth, setRightWidth] = useState(420);
+  const [panelVisibility, setPanelVisibility] = useState({
+    showLeftSidebarInline: true,
+    showRightSidebar: true,
+  });
+  const { showLeftSidebarInline, showRightSidebar } = panelVisibility;
 
   const onResizeLeft = useCallback((delta: number) => {
     setLeftWidth((w) => Math.max(160, Math.min(400, w + delta)));
@@ -692,9 +698,38 @@ export function SdkReference({ scrollTarget }: { scrollTarget?: string[] }) {
     setRightWidth((w) => Math.max(280, Math.min(600, w + delta)));
   }, []);
 
+  const layoutRef = useRef<HTMLDivElement>(null);
   const centerRef = useRef<HTMLDivElement>(null);
   const observerRef = useRef<IntersectionObserver | null>(null);
   const isScrollingRef = useRef(false);
+
+  useEffect(() => {
+    if (!data) return;
+
+    const layout = layoutRef.current;
+    if (!layout) return;
+
+    const updateRightSidebarVisibility = () => {
+      const visibility = getApiReferencePanelVisibility({
+        layoutWidth: layout.getBoundingClientRect().width,
+        leftSidebarWidth: leftWidth,
+        rightSidebarWidth: rightWidth,
+      });
+
+      setPanelVisibility({
+        showLeftSidebarInline: visibility.showLeftSidebarInline,
+        showRightSidebar: visibility.showRightSidebar,
+      });
+    };
+
+    const resizeObserver = new ResizeObserver(updateRightSidebarVisibility);
+    resizeObserver.observe(layout);
+    updateRightSidebarVisibility();
+
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, [data, leftWidth, rightWidth]);
 
   /* -- Fetch data -------------------------------------------------- */
 
@@ -1236,43 +1271,49 @@ export function SdkReference({ scrollTarget }: { scrollTarget?: string[] }) {
             : 'rest';
 
   return (
-    <div className="relative flex h-[calc(100vh-5.5rem)]">
+    <div ref={layoutRef} className="relative flex h-[calc(100vh-5.5rem)]" data-api-reference-layout>
       {/* Mobile sidebar toggle */}
-      <button
-        onClick={() => setSidebarOpen(!sidebarOpen)}
-        className="fixed bottom-4 left-4 z-50 flex h-10 w-10 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-lg lg:hidden"
-        aria-label="Toggle navigation"
-      >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="20"
-          height="20"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
+      {!showLeftSidebarInline && (
+        <button
+          onClick={() => setSidebarOpen(!sidebarOpen)}
+          className="fixed bottom-4 left-4 z-50 flex h-10 w-10 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-lg"
+          aria-label="Toggle navigation"
         >
-          {sidebarOpen ? (
-            <path d="M18 6 6 18M6 6l12 12" />
-          ) : (
-            <>
-              <path d="M4 6h16" />
-              <path d="M4 12h16" />
-              <path d="M4 18h16" />
-            </>
-          )}
-        </svg>
-      </button>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            {sidebarOpen ? (
+              <path d="M18 6 6 18M6 6l12 12" />
+            ) : (
+              <>
+                <path d="M4 6h16" />
+                <path d="M4 12h16" />
+                <path d="M4 18h16" />
+              </>
+            )}
+          </svg>
+        </button>
+      )}
 
       {/* ---- Left sidebar ---- */}
       <aside
         className={cn(
-          'fixed inset-y-22 left-0 z-40 shrink-0 overflow-y-auto border-r border-border/50 bg-muted/20 px-3 py-4 transition-transform lg:relative lg:inset-y-auto lg:translate-x-0',
-          sidebarOpen ? 'translate-x-0' : '-translate-x-full',
+          'left-0 z-40 shrink-0 overflow-y-auto border-r border-border/50 bg-muted/20 px-3 py-4 transition-transform',
+          showLeftSidebarInline
+            ? 'relative inset-y-auto translate-x-0'
+            : cn('fixed inset-y-22', sidebarOpen ? 'translate-x-0' : '-translate-x-full'),
         )}
         style={{ width: leftWidth }}
+        data-api-reference-left-sidebar
+        data-layout-mode={showLeftSidebarInline ? 'inline' : 'overlay'}
       >
         {/* REST resources — one NavSection per source */}
         {restSourcesList.map((restSrc, si) => (
@@ -1449,10 +1490,14 @@ export function SdkReference({ scrollTarget }: { scrollTarget?: string[] }) {
           </NavSection>
         ))}
       </aside>
-      <ResizeHandle side="left" onResize={onResizeLeft} />
+      {showLeftSidebarInline && <ResizeHandle side="left" onResize={onResizeLeft} />}
 
       {/* ---- Center panel ---- */}
-      <main ref={centerRef} className="flex-1 min-w-0 overflow-y-auto bg-muted/10">
+      <main
+        ref={centerRef}
+        className="flex-1 min-w-0 overflow-y-auto bg-muted/10"
+        data-api-reference-center
+      >
         <div className="sticky top-0 z-10 bg-background/80 backdrop-blur-sm border-b border-border/30">
           <DocsBreadcrumb
             segments={[
@@ -2004,103 +2049,108 @@ export function SdkReference({ scrollTarget }: { scrollTarget?: string[] }) {
       </main>
 
       {/* ---- Right sidebar (code snippets) ---- */}
-      <ResizeHandle side="right" onResize={onResizeRight} />
-      <aside
-        className="hidden shrink-0 border-l border-border/50 bg-muted/10 xl:block"
-        style={{ width: rightWidth }}
-      >
-        <div className="sticky top-22 flex max-h-[calc(100vh-5.5rem)] flex-col overflow-y-auto p-3 gap-3">
-          {/* Request card */}
-          <div className="group/code glass-card rounded-xl">
-            {/* Language selector */}
-            <div className="border-b border-border/40 bg-muted/15 px-3 py-2">
-              <Select value={language} onValueChange={selectLanguage}>
-                <SelectTrigger className="h-8 w-full cursor-pointer">
-                  <SelectValue>
-                    <span className="flex items-center gap-2">
-                      <span
-                        className={cn(
-                          'inline-flex h-5 w-7 items-center justify-center rounded bg-muted text-[10px] font-bold',
-                          LANG_COLORS[language],
-                        )}
-                      >
-                        {LANG_ICONS[language] ?? language}
-                      </span>
-                      <span className="text-sm">
-                        {LANGUAGE_DISPLAY_NAMES[language] ?? language}
-                      </span>
-                    </span>
-                  </SelectValue>
-                </SelectTrigger>
-                <SelectContent>
-                  {(data?.languages ?? SUPPORTED_LANGUAGES).map((lang) => (
-                    <SelectItem key={lang} value={lang} className="cursor-pointer">
+      {showRightSidebar && <ResizeHandle side="right" onResize={onResizeRight} />}
+      {showRightSidebar && (
+        <aside
+          className="shrink-0 border-l border-border/50 bg-muted/10"
+          style={{ width: rightWidth }}
+          data-api-reference-right-sidebar
+        >
+          <div className="sticky top-22 flex max-h-[calc(100vh-5.5rem)] flex-col overflow-y-auto p-3 gap-3">
+            {/* Request card */}
+            <div className="group/code glass-card rounded-xl">
+              {/* Language selector */}
+              <div className="border-b border-border/40 bg-muted/15 px-3 py-2">
+                <Select value={language} onValueChange={selectLanguage}>
+                  <SelectTrigger className="h-8 w-full cursor-pointer">
+                    <SelectValue>
                       <span className="flex items-center gap-2">
                         <span
                           className={cn(
                             'inline-flex h-5 w-7 items-center justify-center rounded bg-muted text-[10px] font-bold',
-                            LANG_COLORS[lang],
+                            LANG_COLORS[language],
                           )}
                         >
-                          {LANG_ICONS[lang] ?? lang}
+                          {LANG_ICONS[language] ?? language}
                         </span>
-                        {LANGUAGE_DISPLAY_NAMES[lang] ?? lang}
+                        <span className="text-sm">
+                          {LANGUAGE_DISPLAY_NAMES[language] ?? language}
+                        </span>
                       </span>
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
+                    </SelectValue>
+                  </SelectTrigger>
+                  <SelectContent>
+                    {(data?.languages ?? SUPPORTED_LANGUAGES).map((lang) => (
+                      <SelectItem key={lang} value={lang} className="cursor-pointer">
+                        <span className="flex items-center gap-2">
+                          <span
+                            className={cn(
+                              'inline-flex h-5 w-7 items-center justify-center rounded bg-muted text-[10px] font-bold',
+                              LANG_COLORS[lang],
+                            )}
+                          >
+                            {LANG_ICONS[lang] ?? lang}
+                          </span>
+                          {LANGUAGE_DISPLAY_NAMES[lang] ?? lang}
+                        </span>
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
 
-            {/* Snippet header */}
-            <div className="flex items-center justify-between border-b border-border/40 px-4 py-2">
-              <span className="truncate text-xs text-muted-foreground">
-                {activeItem?.displayName ?? 'SDK Snippet'}
-              </span>
-              <div className="flex items-center gap-1.5">
-                <div className="opacity-0 group-hover/code:opacity-100 transition-opacity">
-                  <CopyButton text={snippet} />
+              {/* Snippet header */}
+              <div className="flex items-center justify-between border-b border-border/40 px-4 py-2">
+                <span className="truncate text-xs text-muted-foreground">
+                  {activeItem?.displayName ?? 'SDK Snippet'}
+                </span>
+                <div className="flex items-center gap-1.5">
+                  <div className="opacity-0 group-hover/code:opacity-100 transition-opacity">
+                    <CopyButton text={snippet} />
+                  </div>
+                  {activeItem && getTryNowConfig() && (
+                    <button
+                      onClick={() => setTryNowOpen(true)}
+                      className="cursor-pointer inline-flex items-center gap-1.5 rounded-lg bg-primary px-3.5 py-1.5 text-sm font-medium text-primary-foreground shadow-sm hover:bg-primary/90 hover:shadow transition-all"
+                    >
+                      <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
+                        <path d="M8 5v14l11-7z" />
+                      </svg>
+                      Try now
+                    </button>
+                  )}
                 </div>
-                {activeItem && getTryNowConfig() && (
-                  <button
-                    onClick={() => setTryNowOpen(true)}
-                    className="cursor-pointer inline-flex items-center gap-1.5 rounded-lg bg-primary px-3.5 py-1.5 text-sm font-medium text-primary-foreground shadow-sm hover:bg-primary/90 hover:shadow transition-all"
-                  >
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
-                      <path d="M8 5v14l11-7z" />
-                    </svg>
-                    Try now
-                  </button>
-                )}
+              </div>
+
+              {/* Code */}
+              <div className="bg-muted/30">
+                <CodeBlock code={snippet} language={language} />
               </div>
             </div>
 
-            {/* Code */}
-            <div className="bg-muted/30">
-              <CodeBlock code={snippet} language={language} />
-            </div>
+            {/* Response card */}
+            {(() => {
+              const op = getActiveOperation();
+              return op?.responses && op.responses.length > 0 ? (
+                <ResponsePanel responses={op.responses} />
+              ) : null;
+            })()}
           </div>
-
-          {/* Response card */}
-          {(() => {
-            const op = getActiveOperation();
-            return op?.responses && op.responses.length > 0 ? (
-              <ResponsePanel responses={op.responses} />
-            ) : null;
-          })()}
-        </div>
-      </aside>
+        </aside>
+      )}
 
       {/* Mobile code panel (collapsible at bottom) */}
-      <MobileCodePanel
-        snippet={snippet}
-        language={language}
-        activeLabel={activeItem?.displayName}
-        languages={[...(data?.languages ?? SUPPORTED_LANGUAGES)]}
-        onSelectLanguage={selectLanguage}
-        selectedLanguage={language}
-        onTryNow={activeItem && getTryNowConfig() ? () => setTryNowOpen(true) : undefined}
-      />
+      {!showRightSidebar && (
+        <MobileCodePanel
+          snippet={snippet}
+          language={language}
+          activeLabel={activeItem?.displayName}
+          languages={[...(data?.languages ?? SUPPORTED_LANGUAGES)]}
+          onSelectLanguage={selectLanguage}
+          selectedLanguage={language}
+          onTryNow={activeItem && getTryNowConfig() ? () => setTryNowOpen(true) : undefined}
+        />
+      )}
 
       {/* Try Now modal — rendered at root level for full-viewport blur */}
       <TryNowModal
@@ -2219,7 +2269,10 @@ function MobileCodePanel({
   const [expanded, setExpanded] = useState(false);
 
   return (
-    <div className={cn('fixed inset-x-0 bottom-0 z-30 xl:hidden', expanded ? 'top-1/3' : '')}>
+    <div
+      className={cn('fixed inset-x-0 bottom-0 z-30', expanded ? 'top-1/3' : '')}
+      data-api-reference-bottom-code-panel
+    >
       <div className="flex w-full items-center border-t bg-muted/40 text-muted-foreground">
         <button
           onClick={() => setExpanded(!expanded)}

--- a/packages/docs-ui/lib/api-reference-layout.ts
+++ b/packages/docs-ui/lib/api-reference-layout.ts
@@ -1,0 +1,35 @@
+export const MIN_API_REFERENCE_CENTER_WIDTH = 280;
+
+const RESIZE_HANDLE_LAYOUT_WIDTH = 4;
+
+interface ApiReferenceLayoutWidths {
+  layoutWidth: number;
+  leftSidebarWidth: number;
+  rightSidebarWidth: number;
+}
+
+export interface ApiReferencePanelVisibility {
+  centerWidthWithRightSidebar: number;
+  showLeftSidebarInline: boolean;
+  showRightSidebar: boolean;
+}
+
+export function getApiReferencePanelVisibility({
+  layoutWidth,
+  leftSidebarWidth,
+  rightSidebarWidth,
+}: ApiReferenceLayoutWidths): ApiReferencePanelVisibility {
+  const centerWidthWithLeftSidebar = layoutWidth - leftSidebarWidth - RESIZE_HANDLE_LAYOUT_WIDTH;
+  const showLeftSidebarInline = centerWidthWithLeftSidebar > MIN_API_REFERENCE_CENTER_WIDTH;
+  const centerWidthWithRightSidebar =
+    layoutWidth -
+    (showLeftSidebarInline ? leftSidebarWidth + RESIZE_HANDLE_LAYOUT_WIDTH : 0) -
+    rightSidebarWidth -
+    RESIZE_HANDLE_LAYOUT_WIDTH;
+
+  return {
+    centerWidthWithRightSidebar,
+    showLeftSidebarInline,
+    showRightSidebar: centerWidthWithRightSidebar > MIN_API_REFERENCE_CENTER_WIDTH,
+  };
+}

--- a/packages/docs-ui/next.config.js
+++ b/packages/docs-ui/next.config.js
@@ -1,15 +1,5 @@
 const path = require('node:path');
 const docsUiRoot = process.env.CORTEX_DOCS_UI_ROOT || __dirname;
-const standaloneWebpackConfig =
-  process.env.CORTEX_STANDALONE_BUILD === '1'
-    ? {
-        transpilePackages: ['@cortex-docs/docs-ui'],
-        webpack(config) {
-          config.resolve.alias['@'] = __dirname;
-          return config;
-        },
-      }
-    : {};
 
 if (process.env.CORTEX_CLOUDFLARE === '1') {
   const { initOpenNextCloudflareForDev } = require('@opennextjs/cloudflare');
@@ -18,8 +8,12 @@ if (process.env.CORTEX_CLOUDFLARE === '1') {
 
 /** @type {import('next').NextConfig} */
 module.exports = {
-  ...standaloneWebpackConfig,
   reactStrictMode: true,
+  transpilePackages: ['@cortex-docs/docs-ui'],
+  webpack(config) {
+    config.resolve.alias['@'] = __dirname;
+    return config;
+  },
   images: {
     remotePatterns: [
       {

--- a/scripts/smoke-cli-package.mjs
+++ b/scripts/smoke-cli-package.mjs
@@ -2,9 +2,12 @@
 
 import { execFileSync, spawn } from 'node:child_process';
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
-import { createServer } from 'node:net';
+import { createServer as createHttpServer } from 'node:http';
+import { createRequire } from 'node:module';
+import { createServer as createNetServer } from 'node:net';
 import { tmpdir } from 'node:os';
 import { isAbsolute, join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 const archiveArgument = process.argv[2];
 const expectedVersion = process.argv[3];
@@ -16,6 +19,7 @@ const archive = isAbsolute(archiveArgument) ? archiveArgument : resolve(archiveA
 const smokeRoot = mkdtempSync(join(tmpdir(), 'cortex-cli-smoke-'));
 const projectDir = join(smokeRoot, 'project');
 const docsOutput = join(projectDir, '.cortex', 'docs-smoke');
+const mcpOutput = join(projectDir, '.cortex', 'mcp-smoke');
 
 function run(command, args, cwd, capture = false) {
   return execFileSync(command, args, {
@@ -25,9 +29,37 @@ function run(command, args, cwd, capture = false) {
   });
 }
 
+function runCapturedAsync(command, args, cwd) {
+  return new Promise((resolveRun, rejectRun) => {
+    const child = spawn(command, args, {
+      cwd,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.once('error', rejectRun);
+    child.once('exit', (code, signal) => {
+      if (code === 0) resolveRun(stdout);
+      else {
+        rejectRun(
+          new Error(
+            `${command} ${args.join(' ')} failed (${signal ? `signal ${signal}` : `exit code ${code ?? 1}`}).\n${stdout}${stderr}`,
+          ),
+        );
+      }
+    });
+  });
+}
+
 function reservePort() {
   return new Promise((resolvePort, reject) => {
-    const server = createServer();
+    const server = createNetServer();
     server.once('error', reject);
     server.listen(0, '127.0.0.1', () => {
       const address = server.address();
@@ -44,27 +76,120 @@ function reservePort() {
   });
 }
 
-async function waitForDocs(url, child, output) {
-  const deadline = Date.now() + 60_000;
+async function waitForPage(url, child, output, expectedText, commandName) {
+  const deadline = Date.now() + 90_000;
   while (Date.now() < deadline) {
     if (child.exitCode !== null) {
-      throw new Error(`cortex docs start exited early.\n${output()}`);
+      throw new Error(`${commandName} exited early.\n${output()}`);
     }
+    let response;
     try {
-      const response = await fetch(url);
-      if (response.ok && (await response.text()).includes('Getting Started')) return;
+      response = await fetch(url);
     } catch {}
+    if (response) {
+      const body = await response.text();
+      if (response.ok && body.includes(expectedText)) return;
+      if (response.status >= 500) {
+        await new Promise((resolveWait) => setTimeout(resolveWait, 250));
+        throw new Error(`${commandName} returned HTTP ${response.status}.\n${output()}`);
+      }
+    }
     await new Promise((resolveWait) => setTimeout(resolveWait, 250));
   }
-  throw new Error(`Timed out while waiting for ${url}.\n${output()}`);
+  throw new Error(`Timed out while waiting for ${commandName} at ${url}.\n${output()}`);
 }
 
-function stopProcessGroup(child) {
+async function stopProcessGroup(child) {
   if (!child.pid || child.exitCode !== null) return;
+  const exited = new Promise((resolveExit) => child.once('exit', resolveExit));
   try {
     process.kill(-child.pid, 'SIGTERM');
   } catch {
     child.kill('SIGTERM');
+  }
+  await Promise.race([exited, new Promise((resolveWait) => setTimeout(resolveWait, 5_000))]);
+}
+
+function spawnCli(cli, args, cwd) {
+  let outputStart = '';
+  let outputEnd = '';
+  const appendOutput = (chunk) => {
+    const text = chunk.toString();
+    outputStart = `${outputStart}${text}`.slice(0, 10_000);
+    outputEnd = `${outputEnd}${text}`.slice(-10_000);
+  };
+  const child = spawn(cli, args, {
+    cwd,
+    detached: true,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  child.stdout.on('data', appendOutput);
+  child.stderr.on('data', appendOutput);
+  return {
+    child,
+    output: () => (outputStart === outputEnd ? outputStart : `${outputStart}\n...\n${outputEnd}`),
+  };
+}
+
+async function startMissingNpmRegistry() {
+  const server = createHttpServer((_request, response) => {
+    response.writeHead(404, { 'content-type': 'application/json' });
+    response.end(JSON.stringify({ error: 'package not found' }));
+  });
+  await new Promise((resolveListen, rejectListen) => {
+    server.once('error', rejectListen);
+    server.listen(0, '127.0.0.1', resolveListen);
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    server.close();
+    throw new Error('Could not start the local npm registry for the publish E2E test.');
+  }
+  return {
+    url: `http://127.0.0.1:${address.port}`,
+    close: () =>
+      new Promise((resolveClose, rejectClose) =>
+        server.close((error) => {
+          if (error) rejectClose(error);
+          else resolveClose();
+        }),
+      ),
+  };
+}
+
+function assertHelp(cli, args, expectedText) {
+  const output = run(cli, [...args, '--help'], smokeRoot, true);
+  if (!output.includes(expectedText)) {
+    throw new Error(`Command help is missing for cortex ${args.join(' ')}.`);
+  }
+}
+
+async function verifyGeneratedMcp() {
+  run('npm', ['install', '--ignore-scripts', '--no-audit', '--no-fund'], mcpOutput);
+  run('npm', ['run', 'build'], mcpOutput);
+
+  const generatedRequire = createRequire(join(mcpOutput, 'package.json'));
+  const { Client } = await import(
+    pathToFileURL(generatedRequire.resolve('@modelcontextprotocol/sdk/client/index.js')).href
+  );
+  const { StdioClientTransport } = await import(
+    pathToFileURL(generatedRequire.resolve('@modelcontextprotocol/sdk/client/stdio.js')).href
+  );
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: [join(mcpOutput, 'dist', 'main.js')],
+    cwd: mcpOutput,
+    stderr: 'pipe',
+  });
+  const client = new Client({ name: 'cortex-cli-package-e2e', version: '1.0.0' });
+  try {
+    await client.connect(transport);
+    const result = await client.listTools();
+    if (result.tools.length === 0) {
+      throw new Error('The MCP server generated by the packaged CLI exposed no tools.');
+    }
+  } finally {
+    await client.close();
   }
 }
 
@@ -87,16 +212,79 @@ try {
     throw new Error(`Unexpected CLI identity. Version: ${version}`);
   }
 
+  for (const [args, expectedText] of [
+    [['init'], 'Initialize a Cortex project'],
+    [['validate'], 'Validate the Cortex config'],
+    [['generate'], 'Regenerate SDKs'],
+    [['publish'], 'Build and publish generated SDKs'],
+    [['docs'], 'API documentation commands'],
+    [['docs', 'serve'], 'Start a local API docs server'],
+    [['docs', 'build'], 'Build production API documentation'],
+    [['docs', 'start'], 'Start a production Cortex Docs build'],
+    [['mcp'], 'MCP server commands'],
+    [['mcp', 'generate'], 'Generate an MCP server'],
+    [['generators'], 'Custom generator template commands'],
+    [['generators', 'export'], 'Export installed generator templates'],
+  ]) {
+    assertHelp(cli, args, expectedText);
+  }
+
   run(cli, ['init', 'registry-smoke'], projectDir);
   run(cli, ['validate'], projectDir);
   run(cli, ['generate', '--dry-run'], projectDir);
   run(cli, ['generate', '--language', 'typescript', '--no-mcp'], projectDir);
-  run(cli, ['mcp', 'generate', '--output', '.cortex/mcp-smoke'], projectDir);
+  const sdkOutput = join(
+    projectDir,
+    'generated',
+    'typescript',
+    'registry-smoke-typescript-client-sdk',
+  );
+  if (!existsSync(join(sdkOutput, 'package.json'))) {
+    throw new Error('cortex generate did not create the TypeScript SDK package.');
+  }
+  run('npm', ['install', '--ignore-scripts', '--no-audit', '--no-fund'], sdkOutput);
+  run('npm', ['run', 'build'], sdkOutput);
+
+  run(cli, ['mcp', 'generate', '--output', mcpOutput], projectDir);
+  await verifyGeneratedMcp();
+
   run(
     cli,
     ['generators', 'export', '--language', 'typescript', '--output', 'cortex-templates'],
     projectDir,
   );
+  if (!existsSync(join(projectDir, 'cortex-templates', 'languages', 'typescript', 'index.ejs'))) {
+    throw new Error('cortex generators export did not create the TypeScript templates.');
+  }
+
+  const registry = await startMissingNpmRegistry();
+  try {
+    const publishOutput = await runCapturedAsync(
+      cli,
+      ['publish', '--dry-run', '--sdk', 'typescript', '--registry', registry.url],
+      projectDir,
+    );
+    if (!publishOutput.includes('Publish plan complete. No packages were uploaded.')) {
+      throw new Error('cortex publish --dry-run did not produce a successful publish plan.');
+    }
+  } finally {
+    await registry.close();
+  }
+
+  const servePort = await reservePort();
+  const docsServe = spawnCli(cli, ['docs', 'serve', '--port', String(servePort)], projectDir);
+  try {
+    await waitForPage(
+      `http://127.0.0.1:${servePort}/docs/quickstart`,
+      docsServe.child,
+      docsServe.output,
+      'Getting Started',
+      'cortex docs serve',
+    );
+  } finally {
+    await stopProcessGroup(docsServe.child);
+  }
+
   run(cli, ['docs', 'build', '--output', docsOutput], projectDir);
 
   if (!existsSync(join(docsOutput, '.cortex-docs-build.json'))) {
@@ -104,29 +292,26 @@ try {
   }
 
   const port = await reservePort();
-  let serverOutput = '';
-  const docsProcess = spawn(
+  const docsStart = spawnCli(
     cli,
     ['docs', 'start', '--output', docsOutput, '--port', String(port)],
-    {
-      cwd: projectDir,
-      detached: true,
-      stdio: ['ignore', 'pipe', 'pipe'],
-    },
+    projectDir,
   );
-  docsProcess.stdout.on('data', (chunk) => {
-    serverOutput += chunk.toString();
-  });
-  docsProcess.stderr.on('data', (chunk) => {
-    serverOutput += chunk.toString();
-  });
   try {
-    await waitForDocs(`http://127.0.0.1:${port}/docs/quickstart`, docsProcess, () => serverOutput);
+    await waitForPage(
+      `http://127.0.0.1:${port}/docs/quickstart`,
+      docsStart.child,
+      docsStart.output,
+      'Getting Started',
+      'cortex docs start',
+    );
   } finally {
-    stopProcessGroup(docsProcess);
+    await stopProcessGroup(docsStart.child);
   }
 
-  console.log(`Smoke-tested ${expectedVersion}: install, generate, MCP, templates, and docs.`);
+  console.log(
+    `E2E-tested ${expectedVersion}: every CLI command, generated SDK and MCP, publish planning, and docs runtimes.`,
+  );
 } finally {
   rmSync(smokeRoot, { recursive: true, force: true });
 }


### PR DESCRIPTION
## Summary
- keep the API-reference left navigation inline while the right code panel moves below at a projected 280px center width
- E2E-test every packaged CLI command, generated SDK compilation, generated MCP handshake, publish planning, and both docs runtimes
- fix registry-installed `cortex docs serve` by using a copied, transpiled Webpack runtime

## Local verification
- `npm run format:check`
- `npm run lint`
- `npm run test:coverage`
- `node scripts/publish-cli.mjs 0.0.0 --dry-run`