### PR TITLE
fix(deploy): retry static asset propagation checks

### DIFF
--- a/scripts/check-demo.mjs
+++ b/scripts/check-demo.mjs
@@ -11,9 +11,13 @@ const paths = [
   '/api/sdk-snippets',
 ];
 const rounds = 5;
+const maximumPropagationAttempts = 12;
+const retryDelayMs = 5_000;
 
-async function check(path, round) {
-  const response = await fetch(`${baseUrl}${path}`, {
+async function check(path, round, cacheBust = false) {
+  const separator = path.includes('?') ? '&' : '?';
+  const suffix = cacheBust ? `${separator}check=${Date.now()}-${round}` : '';
+  const response = await fetch(`${baseUrl}${path}${suffix}`, {
     headers: { 'user-agent': 'cortex-demo-health-check/1.0' },
     signal: AbortSignal.timeout(30_000),
   });
@@ -30,16 +34,52 @@ async function check(path, round) {
   await response.arrayBuffer();
 }
 
+let propagationFailures = [];
+for (let attempt = 1; attempt <= maximumPropagationAttempts; attempt += 1) {
+  const results = await Promise.allSettled(
+    paths.map((path) => check(path, `propagation attempt ${attempt}`, true)),
+  );
+  propagationFailures = results.filter((result) => result.status === 'rejected');
+  if (propagationFailures.length === 0) break;
+  if (attempt < maximumPropagationAttempts) {
+    console.warn(
+      `Demo deployment has not propagated (attempt ${attempt}/${maximumPropagationAttempts}).`,
+    );
+    await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
+  }
+}
+
+if (propagationFailures.length > 0) {
+  throw propagationFailures[0].reason;
+}
+
 for (let round = 1; round <= rounds; round += 1) {
   await Promise.all(paths.map((path) => check(path, round)));
 }
 
-const logoResponse = await fetch(
-  `https://static.cortexdocs.dev/images/built-with-cortex.svg?check=${Date.now()}`,
-  { signal: AbortSignal.timeout(30_000) },
-);
-if (!logoResponse.ok || !logoResponse.headers.get('cache-control')?.includes('max-age=86400')) {
-  throw new Error(`The static Built with Cortex logo returned ${logoResponse.status}.`);
+let logoFailure;
+for (let attempt = 1; attempt <= maximumPropagationAttempts; attempt += 1) {
+  try {
+    const logoResponse = await fetch(
+      `https://static.cortexdocs.dev/images/built-with-cortex.svg?check=${Date.now()}-${attempt}`,
+      { signal: AbortSignal.timeout(30_000) },
+    );
+    if (!logoResponse.ok || !logoResponse.headers.get('cache-control')?.includes('max-age=86400')) {
+      throw new Error(`The static Built with Cortex logo returned ${logoResponse.status}.`);
+    }
+    await logoResponse.arrayBuffer();
+    logoFailure = undefined;
+    break;
+  } catch (error) {
+    logoFailure = error;
+    if (attempt < maximumPropagationAttempts) {
+      await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
+    }
+  }
+}
+
+if (logoFailure) {
+  throw logoFailure;
 }
 
 console.log(`Demo health check passed: ${paths.length * rounds} concurrent requests.`);

--- a/scripts/check-static-site.mjs
+++ b/scripts/check-static-site.mjs
@@ -2,23 +2,53 @@
 
 const baseUrl = process.argv[2]?.replace(/\/$/, '');
 const paths = process.argv.slice(3);
+const maximumAttempts = 12;
+const retryDelayMs = 5_000;
 if (!baseUrl || paths.length === 0) {
   console.error('Usage: node scripts/check-static-site.mjs <base-url> <path...>');
   process.exit(1);
 }
 
-for (const path of paths) {
+async function check(path, attempt) {
   const separator = path.includes('?') ? '&' : '?';
-  const response = await fetch(`${baseUrl}${path}${separator}check=${Date.now()}`, {
-    signal: AbortSignal.timeout(30_000),
-  });
-  if (!response.ok) {
-    throw new Error(`${path} returned ${response.status}: ${(await response.text()).slice(0, 200)}`);
+  try {
+    const response = await fetch(`${baseUrl}${path}${separator}check=${Date.now()}-${attempt}`, {
+      headers: {
+        'cache-control': 'no-cache',
+        'user-agent': 'cortex-static-deployment-check/1.0',
+      },
+      signal: AbortSignal.timeout(30_000),
+    });
+    if (!response.ok) {
+      return `${path} returned ${response.status}: ${(await response.text()).slice(0, 200)}`;
+    }
+    if (response.headers.get('x-cortex-hosting') !== 'cloudflare-static-assets') {
+      await response.arrayBuffer();
+      return `${path} was not served by Cloudflare Static Assets`;
+    }
+    await response.arrayBuffer();
+    return null;
+  } catch (error) {
+    return `${path} failed: ${error instanceof Error ? error.message : String(error)}`;
   }
-  if (response.headers.get('x-cortex-hosting') !== 'cloudflare-static-assets') {
-    throw new Error(`${path} was not served by Cloudflare Static Assets.`);
+}
+
+let failures = [];
+for (let attempt = 1; attempt <= maximumAttempts; attempt += 1) {
+  failures = (await Promise.all(paths.map((path) => check(path, attempt)))).filter(Boolean);
+  if (failures.length === 0) break;
+  if (attempt < maximumAttempts) {
+    console.warn(
+      `Static deployment has not propagated (attempt ${attempt}/${maximumAttempts}): ${failures.join('; ')}`,
+    );
+    await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
   }
-  await response.arrayBuffer();
+}
+
+if (failures.length > 0) {
+  throw new Error(
+    `Static deployment did not propagate after ${maximumAttempts} attempts: ${failures.join('; ')}`,
+  );
 }
 
 console.log(`Static site health check passed for ${baseUrl}: ${paths.length} assets.`);


### PR DESCRIPTION
Promotes the bounded Cloudflare propagation retries from pre-release. This prevents successful assets-only deployments from failing when the runner reaches an edge that still has the previous route for a few seconds.\n\nPR #43 passed the full quality and browser suites.