### PR TITLE
fix(demo): restore interactive streaming transports

### DIFF
--- a/e2e/docs-ui.spec.ts
+++ b/e2e/docs-ui.spec.ts
@@ -54,6 +54,51 @@ test.describe('Docs UI', () => {
     });
   });
 
+  test('keeps the REST pet stream open until it is stopped manually', async ({ page }) => {
+    await page.goto('/api-reference/rest-api-v1/streamPets');
+    await page.getByRole('button', { name: 'Try now' }).click();
+
+    const modal = page.locator('[data-try-now-modal]');
+    await expect(modal).toContainText('http://localhost:4010/pets/stream');
+    await modal.getByRole('button', { name: 'Send Request' }).click();
+    await expect(modal.getByRole('button', { name: 'Stop' })).toBeVisible();
+    await expect
+      .poll(() => modal.locator('[data-try-now-message-direction="received"]').count())
+      .toBeGreaterThanOrEqual(4);
+
+    await modal.getByRole('button', { name: 'Stop' }).click();
+    await expect(modal).toContainText('Request cancelled');
+    await expect(modal.getByRole('button', { name: 'Send Request' })).toBeVisible();
+  });
+
+  test('runs and manually stops a GraphQL subscription', async ({ page }) => {
+    await page.goto('/api-reference/graphql/petAdopted');
+    await page.getByRole('button', { name: 'Try now' }).click();
+
+    const modal = page.locator('[data-try-now-modal]');
+    await expect(modal).toContainText('ws://localhost:4010/graphql');
+    await modal.getByRole('button', { name: 'Subscribe' }).click();
+    await expect(modal.getByRole('button', { name: 'Unsubscribe' })).toBeVisible();
+    await expect
+      .poll(() => modal.locator('[data-try-now-message-direction="received"]').count())
+      .toBeGreaterThanOrEqual(2);
+
+    await modal.getByRole('button', { name: 'Unsubscribe' }).click();
+    await expect(modal.getByRole('button', { name: 'Subscribe' })).toBeVisible();
+  });
+
+  test('executes gRPC calls through the configured browser bridge', async ({ page }) => {
+    await page.goto('/api-reference/grpc/PetService.ListPets');
+    await page.getByRole('button', { name: 'Try now' }).click();
+
+    const modal = page.locator('[data-try-now-modal]');
+    await expect(modal).toContainText('http://localhost:4010/grpc/PetService/ListPets');
+    await modal.getByRole('button', { name: 'Execute' }).click();
+    const response = modal.locator('[data-try-now-response]');
+    await expect(response).toContainText('200 OK');
+    await expect(response).toContainText('pet-1');
+  });
+
   test('renders custom head HTML and serves project assets', async ({ page }) => {
     await page.goto('/');
 

--- a/e2e/docs-ui.spec.ts
+++ b/e2e/docs-ui.spec.ts
@@ -275,7 +275,11 @@ test.describe('Docs UI', () => {
       const input = page.locator('[cmdk-input]');
       await input.fill('list');
       await expect(page.locator('[cmdk-item]').first()).toBeVisible({ timeout: 500 });
+      const initialUrl = page.url();
+      const navigation = page.waitForURL((url) => url.href !== initialUrl);
       await page.locator('[cmdk-item]').first().click();
+      await navigation;
+      await page.waitForLoadState('domcontentloaded');
       await expect(page.locator('[cmdk-input]')).not.toBeVisible();
 
       await page.keyboard.press('Meta+k');

--- a/packages/core/__tests__/config-loader.test.ts
+++ b/packages/core/__tests__/config-loader.test.ts
@@ -322,6 +322,7 @@ describe('ConfigLoader', () => {
             title: 'gRPC',
             type: 'grpc-spec',
             spec: './service.proto',
+            try_now_url: 'http://localhost:4010',
             languages: [{ language: 'typescript', package_name: '@acme/sdk' }],
           },
         ],
@@ -329,6 +330,7 @@ describe('ConfigLoader', () => {
 
       expect(config.sources).toHaveLength(4);
       expect(config.sources[2].endpoint).toBe('http://localhost:4000/graphql');
+      expect(config.sources[3].try_now_url).toBe('http://localhost:4010');
     });
 
     it('rejects unknown fields and protocol-specific fields in the wrong source', () => {
@@ -354,6 +356,21 @@ describe('ConfigLoader', () => {
           ],
         }),
       ).toThrow('An endpoint is only valid for a graphql-spec source');
+
+      expect(() =>
+        loader.validate({
+          project: 'acme',
+          sources: [
+            {
+              title: 'REST',
+              type: 'openapi-spec',
+              spec: './openapi.yaml',
+              try_now_url: 'https://api.example.com',
+              languages: [{ language: 'typescript', package_name: '@acme/sdk' }],
+            },
+          ],
+        }),
+      ).toThrow('A Try now URL is only valid for a grpc-spec or openrpc-spec source');
 
       expect(() =>
         loader.validate({

--- a/packages/core/src/config/schema.ts
+++ b/packages/core/src/config/schema.ts
@@ -147,6 +147,7 @@ const sourceConfigSchema = z
     type: z.enum(sourceTypes),
     spec: z.string().min(1),
     endpoint: z.string().url().optional(),
+    try_now_url: z.string().url().optional(),
     intro: z.string().min(1).optional(),
     languages: z.array(sourceLanguageConfigSchema).min(1),
     websocket: websocketSourceConfigSchema.optional(),
@@ -165,6 +166,13 @@ const sourceConfigSchema = z
         code: z.ZodIssueCode.custom,
         path: ['endpoint'],
         message: 'An endpoint is only valid for a graphql-spec source',
+      });
+    }
+    if (source.try_now_url && source.type !== 'grpc-spec' && source.type !== 'openrpc-spec') {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['try_now_url'],
+        message: 'A Try now URL is only valid for a grpc-spec or openrpc-spec source',
       });
     }
   });

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -105,6 +105,8 @@ export interface SourceConfig {
   spec: string;
   /** Runtime URL for a GraphQL schema source. */
   endpoint?: string;
+  /** Browser-compatible HTTP bridge used by gRPC and OpenRPC Try now requests. */
+  try_now_url?: string;
   intro?: string;
   languages: SourceLanguageConfig[];
   /** AsyncAPI-specific generated client behavior. */

--- a/packages/demo-api/__tests__/worker.test.ts
+++ b/packages/demo-api/__tests__/worker.test.ts
@@ -36,6 +36,29 @@ describe('demo API Worker', () => {
     expect(body.data.map((pet) => pet.name)).toContain('Rex');
   });
 
+  it('streams pets continuously until the client cancels', async () => {
+    const response = await request('/pets/stream');
+    const reader = response.body?.getReader();
+    expect(response.headers.get('Content-Type')).toBe('application/x-ndjson');
+    expect(reader).toBeDefined();
+
+    const decoder = new TextDecoder();
+    const chunks: string[] = [];
+    for (let index = 0; index < 3; index += 1) {
+      const result = await Promise.race([
+        reader!.read(),
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error('The pet stream stopped producing data.')), 1500),
+        ),
+      ]);
+      expect(result.done).toBe(false);
+      chunks.push(decoder.decode(result.value));
+    }
+
+    expect(chunks.map((chunk) => JSON.parse(chunk).id)).toEqual(['pet-1', 'pet-2', 'pet-1']);
+    await reader!.cancel();
+  });
+
   it('executes GraphQL queries', async () => {
     const response = await request('/graphql', {
       method: 'POST',
@@ -45,6 +68,29 @@ describe('demo API Worker', () => {
     const body = (await response.json()) as { data: { pets: { data: Array<{ id: string }> } } };
     expect(response.status).toBe(200);
     expect(body.data.pets.data[0].id).toBe('pet-1');
+  });
+
+  it('serves gRPC browser bridge calls and server streams', async () => {
+    const unaryResponse = await request('/grpc/PetService/ListPets', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}',
+    });
+    const unaryBody = (await unaryResponse.json()) as { data: Array<{ id: string }> };
+    expect(unaryResponse.status).toBe(200);
+    expect(unaryBody.data[0].id).toBe('pet-1');
+
+    const streamResponse = await request('/grpc/PetService/WatchPets', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}',
+    });
+    const reader = streamResponse.body?.getReader();
+    expect(streamResponse.headers.get('Content-Type')).toBe('application/x-ndjson');
+    const first = await reader!.read();
+    expect(first.done).toBe(false);
+    expect(JSON.parse(new TextDecoder().decode(first.value)).id).toBe('pet-1');
+    await reader!.cancel();
   });
 
   it('executes JSON-RPC methods', async () => {

--- a/packages/demo-api/src/index.ts
+++ b/packages/demo-api/src/index.ts
@@ -124,6 +124,46 @@ function withCors(response: Response): Response {
   return new Response(response.body, { status: response.status, headers });
 }
 
+function petStreamResponse(speciesFilter?: string): Response {
+  const encoder = new TextEncoder();
+  let timer: ReturnType<typeof setInterval> | undefined;
+  let active = true;
+  const normalizedFilter = speciesFilter
+    ?.replace(/^SPECIES_/, '')
+    .replace(/^UNSPECIFIED$/, '')
+    .toUpperCase();
+
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      const emitPets = () => {
+        if (!active) return;
+        const matchingPets = normalizedFilter
+          ? pets.filter((pet) => pet.species === normalizedFilter)
+          : pets;
+        for (const pet of matchingPets) {
+          controller.enqueue(encoder.encode(`${JSON.stringify(pet)}\n`));
+        }
+      };
+
+      emitPets();
+      timer = setInterval(emitPets, 1000);
+    },
+    cancel() {
+      active = false;
+      if (timer !== undefined) clearInterval(timer);
+    },
+  });
+
+  return withCors(
+    new Response(stream, {
+      headers: {
+        'Content-Type': 'application/x-ndjson',
+        'Cache-Control': 'no-store',
+      },
+    }),
+  );
+}
+
 async function readJson(request: Request): Promise<Record<string, any>> {
   const text = await request.text();
   return text ? (JSON.parse(text) as Record<string, any>) : {};
@@ -316,7 +356,17 @@ function websocketResponse(request: Request, graphqlSocket: boolean): Response {
   server.addEventListener('close', clearTimers);
   server.addEventListener('error', clearTimers);
 
-  return new Response(null, { status: 101, webSocket: client });
+  const headers = new Headers();
+  const requestedProtocols =
+    request.headers
+      .get('Sec-WebSocket-Protocol')
+      ?.split(',')
+      .map((protocol) => protocol.trim()) ?? [];
+  if (graphqlSocket && requestedProtocols.includes('graphql-transport-ws')) {
+    headers.set('Sec-WebSocket-Protocol', 'graphql-transport-ws');
+  }
+
+  return new Response(null, { status: 101, webSocket: client, headers });
 }
 
 async function handleRequest(request: Request): Promise<Response> {
@@ -362,14 +412,7 @@ async function handleRequest(request: Request): Promise<Response> {
     return json(pet, 201);
   }
   if (path === '/pets/stream' && method === 'GET') {
-    const encoder = new TextEncoder();
-    const stream = new ReadableStream({
-      start(controller) {
-        for (const pet of pets) controller.enqueue(encoder.encode(`${JSON.stringify(pet)}\n`));
-        controller.close();
-      },
-    });
-    return withCors(new Response(stream, { headers: { 'Content-Type': 'application/x-ndjson' } }));
+    return petStreamResponse();
   }
   if (path === '/uploads/raw' && method === 'POST') {
     const body = await request.arrayBuffer();
@@ -421,7 +464,8 @@ async function handleRequest(request: Request): Promise<Response> {
       return json(newPet(body, 'pet-grpc'));
     if (service === 'PetService' && operation === 'UpdatePet') return json({ ...pets[0], ...body });
     if (service === 'PetService' && operation === 'DeletePet') return json({});
-    if (service === 'PetService' && operation === 'WatchPets') return json({ data: pets });
+    if (service === 'PetService' && operation === 'WatchPets')
+      return petStreamResponse(body.species_filter);
     if (service === 'OwnerService' && operation === 'ListOwners') return json({ data: owners });
     if (service === 'OwnerService' && operation === 'GetOwner')
       return json(owners.find((owner) => owner.id === body.id) ?? owners[0]);

--- a/packages/docs-ui/__tests__/search-index.test.ts
+++ b/packages/docs-ui/__tests__/search-index.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { buildSearchDocuments, createSearchIndex, searchIndex } from '@/lib/search-index';
+
+describe('search index routes', () => {
+  it('uses the API source title instead of the resource name for REST result links', () => {
+    const sdkData = {
+      sourceTitles: { rest: ['REST API V1'] },
+      resources: [
+        {
+          name: 'owners',
+          operations: [
+            {
+              operationId: 'listOwners',
+              method: 'GET',
+              path: '/owners',
+              summary: 'List all owners',
+            },
+          ],
+        },
+      ],
+    };
+
+    const documents = buildSearchDocuments(sdkData, null, null);
+    const results = searchIndex(createSearchIndex(documents), 'list owners');
+
+    expect(results[0]).toMatchObject({
+      id: 'rest-listOwners',
+      href: '/api-reference/rest-api-v1/listOwners',
+    });
+  });
+});

--- a/packages/docs-ui/components/docs/docs-header.tsx
+++ b/packages/docs-ui/components/docs/docs-header.tsx
@@ -240,9 +240,18 @@ export function DocsHeader() {
 
   const handleSelect = useCallback(
     (id: string) => {
-      const selectedDoc = displayItems.find((d) => d.id === id);
+      // Prefer the current index entry so older recent-search records, saved before
+      // canonical hrefs were stored, still navigate to the correct destination.
+      const selectedDoc =
+        allDocuments.find((document) => document.id === id) ??
+        displayItems.find((document) => document.id === id);
       if (selectedDoc) addRecentSearch(selectedDoc);
       setSearchOpen(false);
+
+      if (selectedDoc?.href) {
+        router.push(selectedDoc.href);
+        return;
+      }
 
       if (id.startsWith('docs-')) {
         const slug = id.replace('docs-', '');

--- a/packages/docs-ui/components/docs/try-now-modal.tsx
+++ b/packages/docs-ui/components/docs/try-now-modal.tsx
@@ -312,11 +312,15 @@ function MessageLog({ messages }: { messages: LogEntry[] }) {
   }
 
   return (
-    <div className="mt-1 rounded-lg border overflow-hidden max-h-72 overflow-y-auto">
+    <div
+      data-try-now-messages
+      className="mt-1 rounded-lg border overflow-hidden max-h-72 overflow-y-auto"
+    >
       <div className="divide-y divide-border/30">
         {messages.map((m) => (
           <div
             key={m.id}
+            data-try-now-message-direction={m.direction}
             className={cn(
               'px-3 py-1.5 text-xs font-mono',
               m.direction === 'system' && 'bg-muted/30 text-muted-foreground italic',
@@ -697,13 +701,23 @@ export function TryNowModal({
 
           if (race === 'timeout') {
             addLog('system', `${res.status} ${res.statusText}`);
-            for (const line of firstText.split('\n').filter(Boolean)) addLog('received', line);
+            let buffer = firstText;
+            const logCompleteLines = () => {
+              const lines = buffer.split('\n');
+              buffer = lines.pop() ?? '';
+              for (const line of lines) {
+                if (line.trim()) addLog('received', line);
+              }
+            };
+            logCompleteLines();
             let pending = await nextRead;
             while (!pending.done) {
-              const text = decoder.decode(pending.value, { stream: true });
-              for (const line of text.split('\n').filter(Boolean)) addLog('received', line);
+              buffer += decoder.decode(pending.value, { stream: true });
+              logCompleteLines();
               pending = await reader.read();
             }
+            buffer += decoder.decode();
+            if (buffer.trim()) addLog('received', buffer);
             addLog('system', 'Stream ended');
           } else {
             let fullText = firstText;
@@ -1159,6 +1173,7 @@ export function TryNowModal({
 
   return (
     <div
+      data-try-now-modal
       className="fixed inset-0 z-200 flex items-center justify-center"
       style={{ position: 'fixed', top: 0, left: 0, right: 0, bottom: 0 }}
     >
@@ -1598,7 +1613,7 @@ export function TryNowModal({
                   </div>
                 ) : (
                   response && (
-                    <div className="mt-1 rounded-lg border overflow-hidden">
+                    <div data-try-now-response className="mt-1 rounded-lg border overflow-hidden">
                       <div className="flex items-center justify-between border-b bg-muted/40 px-3 py-1.5">
                         <span
                           className={cn(

--- a/packages/docs-ui/lib/recent-searches.ts
+++ b/packages/docs-ui/lib/recent-searches.ts
@@ -5,6 +5,7 @@ const MAX_RECENT = 10;
 
 export interface RecentSearch {
   id: string;
+  href?: string;
   title: string;
   breadcrumb: string;
   resultType: string;
@@ -17,6 +18,7 @@ export interface RecentSearch {
 function toRecentSearch(doc: SearchDocument): RecentSearch {
   return {
     id: doc.id,
+    href: doc.href,
     title: doc.title,
     breadcrumb: doc.breadcrumb,
     resultType: doc.resultType,

--- a/packages/docs-ui/lib/search-index.ts
+++ b/packages/docs-ui/lib/search-index.ts
@@ -111,9 +111,7 @@ export function buildSearchDocuments(sdkData: any, mcpData: any, docsData: any):
 
     if (sdkData.graphql) {
       const graphqlSourceSlug = slugify(
-        sdkData.graphqlSources?.[0]?.title ??
-          sdkData.sourceTitles?.graphql?.[0] ??
-          'graphql',
+        sdkData.graphqlSources?.[0]?.title ?? sdkData.sourceTitles?.graphql?.[0] ?? 'graphql',
       );
       for (const q of sdkData.graphql.queries ?? []) {
         const name = typeof q === 'string' ? q : q.name;
@@ -169,9 +167,7 @@ export function buildSearchDocuments(sdkData: any, mcpData: any, docsData: any):
 
     if (sdkData.websocket) {
       const websocketSourceSlug = slugify(
-        sdkData.websocketSources?.[0]?.title ??
-          sdkData.sourceTitles?.websocket?.[0] ??
-          'websocket',
+        sdkData.websocketSources?.[0]?.title ?? sdkData.sourceTitles?.websocket?.[0] ?? 'websocket',
       );
       for (const ch of sdkData.websocket.channels ?? []) {
         docs.push({
@@ -190,9 +186,7 @@ export function buildSearchDocuments(sdkData: any, mcpData: any, docsData: any):
 
     if (sdkData.openrpc) {
       const openrpcSourceSlug = slugify(
-        sdkData.openrpcSources?.[0]?.title ??
-          sdkData.sourceTitles?.openrpc?.[0] ??
-          'openrpc',
+        sdkData.openrpcSources?.[0]?.title ?? sdkData.sourceTitles?.openrpc?.[0] ?? 'openrpc',
       );
       for (const m of sdkData.openrpc.methods ?? []) {
         const tag = m.tags?.[0] ?? 'OpenRPC';

--- a/packages/docs-ui/lib/search-index.ts
+++ b/packages/docs-ui/lib/search-index.ts
@@ -2,6 +2,7 @@ import MiniSearch from 'minisearch';
 
 export interface SearchDocument {
   id: string;
+  href?: string;
   title: string;
   description: string;
   keywords: string;
@@ -15,6 +16,7 @@ export interface SearchDocument {
 
 const STORED_FIELDS = [
   'id',
+  'href',
   'title',
   'description',
   'group',
@@ -24,6 +26,13 @@ const STORED_FIELDS = [
   'method',
   'source',
 ] as const;
+
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+}
 
 export function createSearchIndex(documents: SearchDocument[]): MiniSearch {
   const index = new MiniSearch({
@@ -68,10 +77,14 @@ export function buildSearchDocuments(sdkData: any, mcpData: any, docsData: any):
   const docs: SearchDocument[] = [];
 
   if (sdkData) {
+    const restSourceSlug = slugify(
+      sdkData.restSources?.[0]?.title ?? sdkData.sourceTitles?.rest?.[0] ?? 'rest',
+    );
     for (const res of sdkData.resources ?? []) {
       for (const op of res.operations ?? []) {
         docs.push({
           id: `rest-${op.operationId}`,
+          href: `/api-reference/${restSourceSlug}/${op.operationId}`,
           title: op.summary || `${op.method} ${op.path}`,
           description: op.summary ?? '',
           keywords: [
@@ -97,12 +110,18 @@ export function buildSearchDocuments(sdkData: any, mcpData: any, docsData: any):
     }
 
     if (sdkData.graphql) {
+      const graphqlSourceSlug = slugify(
+        sdkData.graphqlSources?.[0]?.title ??
+          sdkData.sourceTitles?.graphql?.[0] ??
+          'graphql',
+      );
       for (const q of sdkData.graphql.queries ?? []) {
         const name = typeof q === 'string' ? q : q.name;
         const desc = typeof q === 'string' ? '' : (q.description ?? '');
         const args = typeof q === 'string' ? '' : (q.args?.map((a: any) => a.name).join(' ') ?? '');
         docs.push({
           id: `gql-q-${name}`,
+          href: `/api-reference/${graphqlSourceSlug}/${name}`,
           title: name,
           description: desc,
           keywords: args,
@@ -119,6 +138,7 @@ export function buildSearchDocuments(sdkData: any, mcpData: any, docsData: any):
         const args = typeof m === 'string' ? '' : (m.args?.map((a: any) => a.name).join(' ') ?? '');
         docs.push({
           id: `gql-m-${name}`,
+          href: `/api-reference/${graphqlSourceSlug}/${name}`,
           title: name,
           description: desc,
           keywords: args,
@@ -134,6 +154,7 @@ export function buildSearchDocuments(sdkData: any, mcpData: any, docsData: any):
         const desc = typeof s === 'string' ? '' : (s.description ?? '');
         docs.push({
           id: `gql-s-${name}`,
+          href: `/api-reference/${graphqlSourceSlug}/${name}`,
           title: name,
           description: desc,
           keywords: '',
@@ -147,9 +168,15 @@ export function buildSearchDocuments(sdkData: any, mcpData: any, docsData: any):
     }
 
     if (sdkData.websocket) {
+      const websocketSourceSlug = slugify(
+        sdkData.websocketSources?.[0]?.title ??
+          sdkData.sourceTitles?.websocket?.[0] ??
+          'websocket',
+      );
       for (const ch of sdkData.websocket.channels ?? []) {
         docs.push({
           id: `ws-${ch.name}`,
+          href: `/api-reference/${websocketSourceSlug}/${ch.name}`,
           title: ch.name,
           description: ch.description ?? '',
           keywords: [ch.subscribeMessageName, ch.publishMessageName].filter(Boolean).join(' '),
@@ -162,10 +189,16 @@ export function buildSearchDocuments(sdkData: any, mcpData: any, docsData: any):
     }
 
     if (sdkData.openrpc) {
+      const openrpcSourceSlug = slugify(
+        sdkData.openrpcSources?.[0]?.title ??
+          sdkData.sourceTitles?.openrpc?.[0] ??
+          'openrpc',
+      );
       for (const m of sdkData.openrpc.methods ?? []) {
         const tag = m.tags?.[0] ?? 'OpenRPC';
         docs.push({
           id: `openrpc-${m.name}`,
+          href: `/api-reference/${openrpcSourceSlug}/${m.name}`,
           title: m.name,
           description: m.summary ?? m.description ?? '',
           keywords: [...(m.params?.map((p: any) => p.name) ?? []), m.resultType, ...m.tags]
@@ -185,6 +218,7 @@ export function buildSearchDocuments(sdkData: any, mcpData: any, docsData: any):
       for (const doc of section.documents ?? []) {
         docs.push({
           id: `docs-${doc.slug}`,
+          href: `/docs/${doc.slug}`,
           title: doc.title,
           description: doc.content ? stripHtml(doc.content).slice(0, 500) : '',
           keywords: section.section,

--- a/packages/docs-ui/scripts/dev.mjs
+++ b/packages/docs-ui/scripts/dev.mjs
@@ -5,6 +5,7 @@ import { existsSync, mkdirSync, readFileSync, readdirSync, watch, writeFileSync 
 import { connect } from 'node:net';
 import { resolve, join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import yaml from 'js-yaml';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const DOCS_UI_DIR = resolve(__dirname, '..');
@@ -91,27 +92,52 @@ function initTestProject() {
     writeFileSync(openRpcPath, `${JSON.stringify(document, null, 2)}\n`, 'utf-8');
   }
 
-  let configContent = readFileSync(configPath, 'utf-8').replace(
-    /endpoint:\s*https?:\/\/[^\n]+\/graphql/,
-    `endpoint: ${apiUrl}/graphql`,
+  const grpcSpecPath = join(TEST_PROJECT_DIR, 'specs', 'petstore.proto');
+  mkdirSync(dirname(grpcSpecPath), { recursive: true });
+  writeFileSync(
+    grpcSpecPath,
+    readFileSync(
+      join(WORKSPACE_ROOT, 'packages', 'core', '__fixtures__', 'petstore.proto'),
+      'utf-8',
+    ),
+    'utf-8',
   );
-  configContent = configContent.replace(
-    /( {2}- title: gRPC\n {4}type: grpc-spec\n {4}spec: [^\n]+\n)(?: {4}try_now_url: [^\n]+\n)?/,
-    `$1    try_now_url: ${apiUrl}\n`,
-  );
-  if (!configContent.includes('\ncustom_head_html:')) {
-    configContent = configContent.replace(
-      /^home:/m,
-      [
-        'custom_head_html: |-',
-        '  <meta name="theme-color" content="#ffffff">',
-        '  <link rel="stylesheet" href="/assets/custom.css">',
-        "  <script>document.documentElement.dataset.cortexCustomHead = 'loaded';</script>",
-        'home:',
-      ].join('\n'),
-    );
+
+  const config = yaml.load(readFileSync(configPath, 'utf-8'));
+  if (!config || typeof config !== 'object' || !Array.isArray(config.sources)) {
+    throw new Error('The test project configuration does not contain a sources array.');
   }
-  writeFileSync(configPath, configContent, 'utf-8');
+  const graphqlSource = config.sources.find((source) => source.type === 'graphql-spec');
+  if (graphqlSource) graphqlSource.endpoint = `${apiUrl}/graphql`;
+
+  let grpcSource = config.sources.find((source) => source.type === 'grpc-spec');
+  if (!grpcSource) {
+    const restSource = config.sources.find((source) => source.type === 'openapi-spec');
+    const typescriptLanguage = restSource?.languages?.find(
+      (language) => language.language === 'typescript',
+    );
+    grpcSource = {
+      title: 'gRPC',
+      type: 'grpc-spec',
+      spec: './specs/petstore.proto',
+      languages: [
+        typescriptLanguage ?? {
+          language: 'typescript',
+          package_name: '@petstore/typescript-client-sdk',
+          github_repository: 'github.com/petstore/typescript-client-sdk',
+        },
+      ],
+    };
+    config.sources.push(grpcSource);
+  }
+  grpcSource.try_now_url = apiUrl;
+
+  config.custom_head_html ??= [
+    '<meta name="theme-color" content="#ffffff">',
+    '<link rel="stylesheet" href="/assets/custom.css">',
+    "<script>document.documentElement.dataset.cortexCustomHead = 'loaded';</script>",
+  ].join('\n');
+  writeFileSync(configPath, yaml.dump(config, { lineWidth: 120, noRefs: true }), 'utf-8');
   mkdirSync(join(TEST_PROJECT_DIR, 'assets'), { recursive: true });
   writeFileSync(
     join(TEST_PROJECT_DIR, 'assets', 'custom.css'),

--- a/packages/docs-ui/scripts/dev.mjs
+++ b/packages/docs-ui/scripts/dev.mjs
@@ -96,7 +96,7 @@ function initTestProject() {
     `endpoint: ${apiUrl}/graphql`,
   );
   configContent = configContent.replace(
-    /(  - title: gRPC\n    type: grpc-spec\n    spec: [^\n]+\n)(?:    try_now_url: [^\n]+\n)?/,
+    /( {2}- title: gRPC\n {4}type: grpc-spec\n {4}spec: [^\n]+\n)(?: {4}try_now_url: [^\n]+\n)?/,
     `$1    try_now_url: ${apiUrl}\n`,
   );
   if (!configContent.includes('\ncustom_head_html:')) {

--- a/packages/docs-ui/scripts/dev.mjs
+++ b/packages/docs-ui/scripts/dev.mjs
@@ -95,6 +95,10 @@ function initTestProject() {
     /endpoint:\s*https?:\/\/[^\n]+\/graphql/,
     `endpoint: ${apiUrl}/graphql`,
   );
+  configContent = configContent.replace(
+    /(  - title: gRPC\n    type: grpc-spec\n    spec: [^\n]+\n)(?:    try_now_url: [^\n]+\n)?/,
+    `$1    try_now_url: ${apiUrl}\n`,
+  );
   if (!configContent.includes('\ncustom_head_html:')) {
     configContent = configContent.replace(
       /^home:/m,

--- a/packages/docs-ui/scripts/prepare-demo.mjs
+++ b/packages/docs-ui/scripts/prepare-demo.mjs
@@ -154,6 +154,7 @@ export function prepareDemo(apiUrl = process.env.CORTEX_DEMO_API_URL || 'http://
         title: 'gRPC',
         type: 'grpc-spec',
         spec: './specs/petstore.proto',
+        try_now_url: apiUrl,
         languages: [languages[0]],
       },
       {


### PR DESCRIPTION
## Summary
- keep the REST pet stream and gRPC WatchPets stream open until the user stops them
- negotiate the GraphQL subscription WebSocket protocol correctly
- configure and validate the gRPC Try now browser bridge
- add Worker, configuration, and browser regression coverage

## Local verification
- demo API tests: 8 passed
- core configuration tests: 21 passed
- docs UI tests: 14 passed
- TypeScript, ESLint, and static demo build passed
- live local REST, GraphQL subscription, and gRPC transport checks passed