### PR TITLE
Fix Cloudflare WAF rule updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,22 @@ The project uses Semantic Versioning. Each release contains the same three chang
 
 - None.
 
+## [0.1.20] - 2026-08-26
+
+### New Features
+
+- Added a `try_now_url` source option for gRPC and OpenRPC specs, enabling the "Try now" panel to stream live, real-time responses (e.g. server-streaming/watch operations) through a browser-compatible HTTP bridge.
+
+### Bug Fixes
+
+- Fixed search results navigating to the wrong page; selecting a REST, GraphQL, WebSocket, or OpenRPC result (including from recent searches) now opens its canonical API reference route.
+- Fixed streaming responses in the "Try now" panel being logged as garbled or incomplete lines when chunks split mid-line; output is now buffered and displayed as complete lines.
+- Fixed WebSocket connections dropping the `graphql-transport-ws` subprotocol negotiation, which could break interactive GraphQL subscription testing.
+
+### Improvements
+
+- None.
+
 ## [0.1.19] - 2026-08-26
 
 ### New Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -19807,7 +19807,7 @@
     },
     "packages/cli": {
       "name": "@cortex-docs/cli",
-      "version": "0.1.19",
+      "version": "0.1.20",
       "bundleDependencies": [
         "@cortex-docs/core",
         "@cortex-docs/codegen",
@@ -19896,9 +19896,9 @@
     },
     "packages/docs-site": {
       "name": "@cortex-docs/docs-site",
-      "version": "0.1.19",
+      "version": "0.1.20",
       "dependencies": {
-        "@cortex-docs/cli": "0.1.19"
+        "@cortex-docs/cli": "0.1.20"
       }
     },
     "packages/docs-ui": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cortex-docs/cli",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "description": "Cortex Docs CLI for SDKs, API documentation, and MCP servers",
   "license": "MIT",
   "repository": {

--- a/packages/docs-site/package.json
+++ b/packages/docs-site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cortex-docs/docs-site",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "private": true,
   "description": "Product documentation for Cortex Docs",
   "scripts": {
@@ -9,6 +9,6 @@
     "clean": "rm -rf .cortex"
   },
   "dependencies": {
-    "@cortex-docs/cli": "0.1.19"
+    "@cortex-docs/cli": "0.1.20"
   }
 }

--- a/scripts/configure-cloudflare-security.mjs
+++ b/scripts/configure-cloudflare-security.mjs
@@ -86,7 +86,7 @@ async function ensureRule({ phase, rulesetName, desiredRule, maximumRules }) {
   const existingRule = ruleset.rules?.find((rule) => rule.ref === desiredRule.ref);
   if (existingRule) {
     await cloudflare(`/zones/${zoneId}/rulesets/${ruleset.id}/rules/${existingRule.id}`, {
-      method: 'PUT',
+      method: 'PATCH',
       body: JSON.stringify(desiredRule),
     });
     console.log(`Updated ${desiredRule.ref}.`);


### PR DESCRIPTION
## Summary

- use the current Cloudflare Rulesets API `PATCH` method for single-rule updates
- keep repeat demo deployments idempotent after security rules already exist
- sync the v0.1.20 release commit back into `pre-release`

## Verification

- Cloudflare security dry-run passes
- ESLint and Prettier pass for the deployment script
- the previous deployment completed the Worker, static site, and concurrent live check; only the obsolete `PUT` method returned 405