### PR TITLE
Fix Cloudflare WAF rule updates

### DIFF
--- a/scripts/configure-cloudflare-security.mjs
+++ b/scripts/configure-cloudflare-security.mjs
@@ -86,7 +86,7 @@ async function ensureRule({ phase, rulesetName, desiredRule, maximumRules }) {
   const existingRule = ruleset.rules?.find((rule) => rule.ref === desiredRule.ref);
   if (existingRule) {
     await cloudflare(`/zones/${zoneId}/rulesets/${ruleset.id}/rules/${existingRule.id}`, {
-      method: 'PUT',
+      method: 'PATCH',
       body: JSON.stringify(desiredRule),
     });
     console.log(`Updated ${desiredRule.ref}.`);


### PR DESCRIPTION
## Summary

- use Cloudflare’s current `PATCH` method for updating an existing Rulesets API rule
- prevent successful demo deployments from being marked failed during final WAF reconciliation

## Verification

- quality, coverage, package, browser, and static-browser suites passed in PR #47
- the previous demo upload and concurrent production check passed; the obsolete update method was the only failed step