### PR TITLE
ci: restore and harden demo deployments

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -5,6 +5,12 @@ on:
     workflows: [CI]
     types: [completed]
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Git ref to deploy
+        required: false
+        default: main
 
 permissions:
   contents: read
@@ -17,16 +23,17 @@ jobs:
   deploy:
     name: deploy demo static site and API
     if: >-
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'push' &&
-      github.event.workflow_run.head_branch == 'main' &&
-      !startsWith(github.event.workflow_run.head_commit.message, 'chore(release):')
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'push' &&
+       github.event.workflow_run.head_branch == 'main' &&
+       !startsWith(github.event.workflow_run.head_commit.message, 'chore(release):'))
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.event.workflow_run.head_sha }}
       - uses: actions/setup-node@v7
         with:
           node-version: 22


### PR DESCRIPTION
## Summary
- promote the tested manual demo-deployment trigger
- retain automatic deployment after successful `main` CI
- deploy the Cloudflare WAF `PATCH` hotfix now that Actions billing is restored

## Validation
- feature PR quality and browser checks passed
- promotion checks must pass before merge