### PR TITLE
docs: link the official website

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ One project can combine OpenAPI, AsyncAPI, GraphQL, Protocol Buffer, and OpenRPC
 
 **[Open the Cortex Docs demo →](https://demo.cortexdocs.dev)**
 
+**[Official Website →](https://cortexdocs.dev)**
+
 ## Features
 
 - Generate SDKs for TypeScript, Python, Go, Java, Kotlin, Ruby, PHP, C#, Rust, C++, and C.


### PR DESCRIPTION
## Summary
- add the official Cortex website link to the root README
- preserve the existing demo link

## Validation
- git diff --check
- compared with the existing local README change